### PR TITLE
Update endpoints used for MFA operations

### DIFF
--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -32,12 +32,8 @@ class TestMfa(object):
         return ["Your code is {{code}}"]
 
     @pytest.fixture
-    def mock_verify_factor_payload(self):
-        return ["auth_challenge_01FWRY5H0XXXX0JGGVTY6QFX7X", "626592"]
-
-    @pytest.fixture
     def mock_verify_challenge_payload(self):
-        return ["626592"]
+        return ["auth_challenge_01FWRY5H0XXXX0JGGVTY6QFX7X", "626592"]
 
     @pytest.fixture
     def mock_enroll_factor_response_sms(self):
@@ -174,27 +170,27 @@ class TestMfa(object):
         )
         assert challenge_factor == mock_challenge_factor_response
 
-    def test_legacy_verify_factor_no_id(self, mock_verify_factor_payload):
+    def test_verify_factor_no_id(self, mock_verify_challenge_payload):
         with pytest.raises(ValueError) as err:
             self.mfa.verify_factor(
-                authentication_challenge_id=None, code=mock_verify_factor_payload[1]
+                authentication_challenge_id=None, code=mock_verify_challenge_payload[1]
             )
         assert (
             "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
             in str(err.value)
         )
 
-    def test_legacy_verify_factor_no_code(self, mock_verify_factor_payload):
+    def test_verify_factor_no_code(self, mock_verify_challenge_payload):
         with pytest.raises(ValueError) as err:
             self.mfa.verify_factor(
-                authentication_challenge_id=mock_verify_factor_payload[0], code=None
+                authentication_challenge_id=mock_verify_challenge_payload[0], code=None
             )
         assert (
             "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
             in str(err.value)
         )
 
-    def test_legacy_verify_success(
+    def test_verify_factor_success(
         self, mock_verify_factor_response, mock_request_method
     ):
         mock_request_method("post", mock_verify_factor_response, 200)
@@ -203,9 +199,9 @@ class TestMfa(object):
         )
         assert verify_factor == mock_verify_factor_response
 
-    def test_verify_factor_no_id(self, mock_verify_challenge_payload):
+    def test_verify_challenge_no_id(self, mock_verify_challenge_payload):
         with pytest.raises(ValueError) as err:
-            self.mfa.verify_factor(
+            self.mfa.verify_challenge(
                 authentication_challenge_id=None, code=mock_verify_challenge_payload[1]
             )
             assert (
@@ -213,9 +209,9 @@ class TestMfa(object):
                 in str(err.value)
             )
 
-    def test_verify_factor_no_code(self, mock_verify_challenge_payload):
+    def test_verify_challenge_no_code(self, mock_verify_challenge_payload):
         with pytest.raises(ValueError) as err:
-            self.mfa.verify_factor(
+            self.mfa.verify_challenge(
                 authentication_challenge_id=mock_verify_challenge_payload[0], code=None
             )
             assert (
@@ -225,7 +221,7 @@ class TestMfa(object):
 
     def test_verify_success(self, mock_verify_challenge_response, mock_request_method):
         mock_request_method("post", mock_verify_challenge_response, 200)
-        verify_factor = self.mfa.verify_factor(
+        verify_challenge = self.mfa.verify_challenge(
             "auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT", "093647"
         )
-        assert verify_factor == mock_verify_challenge_response
+        assert verify_challenge == mock_verify_challenge_response

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -29,11 +29,15 @@ class TestMfa(object):
 
     @pytest.fixture
     def mock_challenge_factor_payload(self):
-        return ["auth_factor_01FWRSPQ2XXXQKBCY5AAW5T59W", "Your code is {{code}}"]
+        return ["Your code is {{code}}"]
 
     @pytest.fixture
     def mock_verify_factor_payload(self):
         return ["auth_challenge_01FWRY5H0XXXX0JGGVTY6QFX7X", "626592"]
+
+    @pytest.fixture
+    def mock_verify_challenge_payload(self):
+        return ["626592"]
 
     @pytest.fixture
     def mock_enroll_factor_response_sms(self):
@@ -74,7 +78,7 @@ class TestMfa(object):
         }
 
     @pytest.fixture
-    def mock_verify_factor_response(self):
+    def mock_verify_challenge_response(self):
         return {
             "challenge": {
                 "object": "authentication_challenge",
@@ -170,7 +174,7 @@ class TestMfa(object):
         )
         assert challenge_factor == mock_challenge_factor_response
 
-    def test_verify_factor_no_id(self, mock_verify_factor_payload):
+    def test_legacy_verify_factor_no_id(self, mock_verify_factor_payload):
         with pytest.raises(ValueError) as err:
             self.mfa.verify_factor(
                 authentication_challenge_id=None, code=mock_verify_factor_payload[1]
@@ -180,7 +184,7 @@ class TestMfa(object):
             in str(err.value)
         )
 
-    def test_verify_factor_no_code(self, mock_verify_factor_payload):
+    def test_legacy_verify_factor_no_code(self, mock_verify_factor_payload):
         with pytest.raises(ValueError) as err:
             self.mfa.verify_factor(
                 authentication_challenge_id=mock_verify_factor_payload[0], code=None
@@ -190,9 +194,38 @@ class TestMfa(object):
             in str(err.value)
         )
 
-    def test_verify_success(self, mock_verify_factor_response, mock_request_method):
+    def test_legacy_verify_success(
+        self, mock_verify_factor_response, mock_request_method
+    ):
         mock_request_method("post", mock_verify_factor_response, 200)
         verify_factor = self.mfa.verify_factor(
             "auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT", "093647"
         )
         assert verify_factor == mock_verify_factor_response
+
+    def test_verify_factor_no_id(self, mock_verify_challenge_payload):
+        with pytest.raises(ValueError) as err:
+            self.mfa.verify_factor(
+                authentication_challenge_id=None, code=mock_verify_challenge_payload[1]
+            )
+            assert (
+                "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
+                in str(err.value)
+            )
+
+    def test_verify_factor_no_code(self, mock_verify_challenge_payload):
+        with pytest.raises(ValueError) as err:
+            self.mfa.verify_factor(
+                authentication_challenge_id=mock_verify_challenge_payload[0], code=None
+            )
+            assert (
+                "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
+                in str(err.value)
+            )
+
+    def test_verify_success(self, mock_verify_challenge_response, mock_request_method):
+        mock_request_method("post", mock_verify_challenge_response, 200)
+        verify_factor = self.mfa.verify_factor(
+            "auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT", "093647"
+        )
+        assert verify_factor == mock_verify_challenge_response

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -29,7 +29,7 @@ class TestMfa(object):
 
     @pytest.fixture
     def mock_challenge_factor_payload(self):
-        return ["Your code is {{code}}"]
+        return ["auth_factor_01FWRSPQ2XXXQKBCY5AAW5T59W", "Your code is {{code}}"]
 
     @pytest.fixture
     def mock_verify_challenge_payload(self):
@@ -191,13 +191,13 @@ class TestMfa(object):
         )
 
     def test_verify_factor_success(
-        self, mock_verify_factor_response, mock_request_method
+        self, mock_verify_challenge_response, mock_request_method
     ):
-        mock_request_method("post", mock_verify_factor_response, 200)
+        mock_request_method("post", mock_verify_challenge_response, 200)
         verify_factor = self.mfa.verify_factor(
             "auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT", "093647"
         )
-        assert verify_factor == mock_verify_factor_response
+        assert verify_factor == mock_verify_challenge_response
 
     def test_verify_challenge_no_id(self, mock_verify_challenge_payload):
         with pytest.raises(ValueError) as err:

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 __author__ = "WorkOS"
 

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -119,6 +119,8 @@ class Mfa(object):
         """
         Verifies the one time password provided by the end-user.
 
+        Deprecated: Please use `verify_challenge` instead.
+
         Kwargs:
             authentication_challenge_id (str) - The ID of the authentication challenge that provided the user the verification code.
             code (str) - The verification code sent to and provided by the end user.

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import workos
 from workos.utils.request import (
     RequestHelper,
@@ -5,10 +7,6 @@ from workos.utils.request import (
 )
 from workos.utils.validation import MFA_MODULE, validate_settings
 from workos.resources.mfa import WorkOSChallenge
-
-ENROLL_PATH = "auth/factors/enroll"
-CHALLENGE_PATH = "auth/factors/challenge"
-VERIFY_PATH = "auth/factors/verify"
 
 
 class Mfa(object):
@@ -72,7 +70,7 @@ class Mfa(object):
             )
 
         return self.request_helper.request(
-            ENROLL_PATH,
+            "auth/factors/enroll",
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,
@@ -94,7 +92,6 @@ class Mfa(object):
         """
 
         params = {
-            "authentication_factor_id": authentication_factor_id,
             "sms_template": sms_template,
         }
 
@@ -104,7 +101,9 @@ class Mfa(object):
             )
 
         response = self.request_helper.request(
-            CHALLENGE_PATH,
+            "auth/factors/{factor_id}/challenge".format(
+                factor_id=authentication_factor_id
+            ),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,
@@ -127,6 +126,11 @@ class Mfa(object):
         Returns: Dict containing the  challenge factor details.
         """
 
+        warn(
+            "'verify_factor' is deprecated. Please use 'verify_challenge' instead.",
+            DeprecationWarning,
+        )
+
         params = {
             "authentication_challenge_id": authentication_challenge_id,
             "code": code,
@@ -138,7 +142,40 @@ class Mfa(object):
             )
 
         return self.request_helper.request(
-            VERIFY_PATH,
+            "auth/factors/verify",
+            method=REQUEST_METHOD_POST,
+            params=params,
+            token=workos.api_key,
+        )
+
+    def verify_challenge(
+        self,
+        authentication_challenge_id=None,
+        code=None,
+    ):
+        """
+        Verifies the one time password provided by the end-user.
+
+        Kwargs:
+            authentication_challenge_id (str) - The ID of the authentication challenge that provided the user the verification code.
+            code (str) - The verification code sent to and provided by the end user.
+
+        Returns: Dict containing the  challenge factor details.
+        """
+
+        params = {
+            "code": code,
+        }
+
+        if authentication_challenge_id is None or code is None:
+            raise ValueError(
+                "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
+            )
+
+        return self.request_helper.request(
+            "auth/challenges/{challenge_id}/verify".format(
+                challenge_id=authentication_challenge_id
+            ),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -131,22 +131,7 @@ class Mfa(object):
             DeprecationWarning,
         )
 
-        params = {
-            "authentication_challenge_id": authentication_challenge_id,
-            "code": code,
-        }
-
-        if authentication_challenge_id is None or code is None:
-            raise ValueError(
-                "Incomplete arguments: 'authentication_challenge_id' and 'code' are required parameters"
-            )
-
-        return self.request_helper.request(
-            "auth/factors/verify",
-            method=REQUEST_METHOD_POST,
-            params=params,
-            token=workos.api_key,
-        )
+        return self.verify_challenge(authentication_challenge_id, code)
 
     def verify_challenge(
         self,


### PR DESCRIPTION
This PR updates the endpoints used for two of the MFA operations:

- `challenge_factor`
- `verify_challenge`

The `verify_factor` method is now deprecated and has been replaced with `verify_challenge`. `verify_factor` will be removed in the next major version.

Resolves SDK-547.