### PR TITLE
Update CODEOWNERS after organization rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Pythonistas Team
-* @workos-inc/python
+* @workos/python


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file after the GitHub organization rename.