### PR TITLE
Add Audit Logs to the Python SDK

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def mock_raw_request_method(monkeypatch):
 
 @pytest.fixture
 def capture_and_mock_request(monkeypatch):
-    def inner(method, response_dict, status_code):
+    def inner(method, response_dict, status_code, headers=None):
         request_args = []
         request_kwargs = {}
 
@@ -71,7 +71,7 @@ def capture_and_mock_request(monkeypatch):
             request_args.extend(args)
             request_kwargs.update(kwargs)
 
-            return MockResponse(response_dict, status_code)
+            return MockResponse(response_dict, status_code, headers=headers)
 
         monkeypatch.setattr(requests, method, capture_and_mock)
 

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -21,7 +21,7 @@ class TestAuditLogs:
             organization_id = "org_123456789"
 
             event = {
-                "action": 'document.updated',
+                "action": "document.updated",
                 "occurred_at": datetime.now().isoformat(),
                 "actor": {
                     "id": "user_1",
@@ -30,8 +30,8 @@ class TestAuditLogs:
                 },
                 "targets": [
                     {
-                        "id": 'document_39127',
-                        "type": 'document',
+                        "id": "document_39127",
+                        "type": "document",
                     },
                 ],
                 "context": {
@@ -40,17 +40,19 @@ class TestAuditLogs:
                 },
                 "metadata": {
                     "successful": True,
-                }
+                },
             }
 
-            _, request_kwargs = capture_and_mock_request(
-                "post", {"success": True}, 200)
+            _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
 
             response = self.audit_logs.create_event(
-                organization_id, event, "test_123456")
+                organization_id, event, "test_123456"
+            )
 
             assert request_kwargs["json"] == {
-                "organization_id": organization_id, "event": event}
+                "organization_id": organization_id,
+                "event": event,
+            }
             assert response == True
 
         def test_sends_idempotency_key(self, capture_and_mock_request):
@@ -59,7 +61,7 @@ class TestAuditLogs:
             organization_id = "org_123456789"
 
             event = {
-                "action": 'document.updated',
+                "action": "document.updated",
                 "occurred_at": datetime.now().isoformat(),
                 "actor": {
                     "id": "user_1",
@@ -68,8 +70,8 @@ class TestAuditLogs:
                 },
                 "targets": [
                     {
-                        "id": 'document_39127',
-                        "type": 'document',
+                        "id": "document_39127",
+                        "type": "document",
                     },
                 ],
                 "context": {
@@ -78,53 +80,54 @@ class TestAuditLogs:
                 },
                 "metadata": {
                     "successful": True,
-                }
+                },
             }
 
-            _, request_kwargs = capture_and_mock_request(
-                "post",
-                {"success": True},
-                200
-            )
+            _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
 
             response = self.audit_logs.create_event(
-                organization_id, event, idempotency_key)
+                organization_id, event, idempotency_key
+            )
 
             assert request_kwargs["headers"]["idempotency-key"] == idempotency_key
             assert response == True
 
         def test_throws_unauthorized_excpetion(self, mock_request_method):
             organization_id = "org_123456789"
-            event = {
-                "any_event": "event"
-            }
+            event = {"any_event": "event"}
 
             mock_request_method(
                 "post",
                 {"message": "Unauthorized"},
                 401,
-                {"X-Request-ID": "a-request-id"}
+                {"X-Request-ID": "a-request-id"},
             )
 
             with pytest.raises(AuthenticationException) as excinfo:
-                self.audit_logs.create_event(
-                    organization_id, event)
-            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)
+                self.audit_logs.create_event(organization_id, event)
+            assert "(message=Unauthorized, request_id=a-request-id)" == str(
+                excinfo.value
+            )
 
         def test_throws_badrequest_excpetion(self, mock_request_method):
             organization_id = "org_123456789"
-            event = {
-                "any_event": "any_event"
-            }
+            event = {"any_event": "any_event"}
 
-            mock_request_method("post", {"message": "Audit Log could not be processed due to missing or incorrect data.",
-                                         "code": "invalid_audit_log"}, 400)
+            mock_request_method(
+                "post",
+                {
+                    "message": "Audit Log could not be processed due to missing or incorrect data.",
+                    "code": "invalid_audit_log",
+                },
+                400,
+            )
 
             with pytest.raises(BadRequestException) as excinfo:
-                self.audit_logs.create_event(
-                    organization_id, event)
-            assert '(message=Audit Log could not be processed due to missing or incorrect data.)' == str(
-                excinfo.value)
+                self.audit_logs.create_event(organization_id, event)
+            assert (
+                "(message=Audit Log could not be processed due to missing or incorrect data.)"
+                == str(excinfo.value)
+            )
 
     class TestCreateExport(_TestSetup):
         def test_succeeds(self, mock_request_method):
@@ -133,24 +136,18 @@ class TestAuditLogs:
             range_end = datetime.now().isoformat
 
             expected_payload = {
-                "object": 'audit_log_export',
-                "id": 'audit_log_export_1234',
-                "state": 'pending',
+                "object": "audit_log_export",
+                "id": "audit_log_export_1234",
+                "state": "pending",
                 "url": None,
                 "created_at": datetime.now().isoformat,
                 "updated_at": datetime.now().isoformat,
             }
 
-            mock_request_method(
-                "post",
-                expected_payload,
-                201
-            )
+            mock_request_method("post", expected_payload, 201)
 
             response = self.audit_logs.create_export(
-                organization_id,
-                range_start,
-                range_end
+                organization_id, range_start, range_end
             )
 
             assert response == expected_payload
@@ -159,24 +156,20 @@ class TestAuditLogs:
             organization_id = "org_123456789"
             range_start = datetime.now().isoformat
             range_end = datetime.now().isoformat
-            actions = ['foo', 'bar']
-            actors = ['Jon', 'Smith']
-            targets = ['user', 'team']
+            actions = ["foo", "bar"]
+            actors = ["Jon", "Smith"]
+            targets = ["user", "team"]
 
             expected_payload = {
-                "object": 'audit_log_export',
-                "id": 'audit_log_export_1234',
-                "state": 'pending',
+                "object": "audit_log_export",
+                "id": "audit_log_export_1234",
+                "state": "pending",
                 "url": None,
                 "created_at": datetime.now().isoformat,
                 "updated_at": datetime.now().isoformat,
             }
 
-            mock_request_method(
-                "post",
-                expected_payload,
-                201
-            )
+            mock_request_method("post", expected_payload, 201)
 
             response = self.audit_logs.create_export(
                 actions=actions,
@@ -184,7 +177,7 @@ class TestAuditLogs:
                 organization_id=organization_id,
                 range_end=range_end,
                 range_start=range_start,
-                targets=targets
+                targets=targets,
             )
 
             assert response == expected_payload
@@ -198,33 +191,27 @@ class TestAuditLogs:
                 "post",
                 {"message": "Unauthorized"},
                 401,
-                {"X-Request-ID": "a-request-id"}
+                {"X-Request-ID": "a-request-id"},
             )
 
             with pytest.raises(AuthenticationException) as excinfo:
-                self.audit_logs.create_export(
-                    organization_id,
-                    range_start,
-                    range_end
-                )
-            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)
+                self.audit_logs.create_export(organization_id, range_start, range_end)
+            assert "(message=Unauthorized, request_id=a-request-id)" == str(
+                excinfo.value
+            )
 
     class TestGetExport(_TestSetup):
         def test_succeeds(self, mock_request_method):
             expected_payload = {
-                "object": 'audit_log_export',
-                "id": 'audit_log_export_1234',
-                "state": 'pending',
+                "object": "audit_log_export",
+                "id": "audit_log_export_1234",
+                "state": "pending",
                 "url": None,
                 "created_at": datetime.now().isoformat,
                 "updated_at": datetime.now().isoformat,
             }
 
-            mock_request_method(
-                "get",
-                expected_payload,
-                200
-            )
+            mock_request_method("get", expected_payload, 200)
 
             response = self.audit_logs.get_export(
                 expected_payload["id"],
@@ -237,10 +224,12 @@ class TestAuditLogs:
                 "get",
                 {"message": "Unauthorized"},
                 401,
-                {"X-Request-ID": "a-request-id"}
+                {"X-Request-ID": "a-request-id"},
             )
 
             with pytest.raises(AuthenticationException) as excinfo:
-                self.audit_logs.get_export('audit_log_export_1234')
+                self.audit_logs.get_export("audit_log_export_1234")
 
-            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)
+            assert "(message=Unauthorized, request_id=a-request-id)" == str(
+                excinfo.value
+            )

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import json
-from unittest.mock import Mock
 from requests import Response
 
 import pytest

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -7,6 +7,7 @@ import pytest
 import workos
 from workos.audit_logs import AuditLogs
 from workos.exceptions import AuthenticationException, BadRequestException
+from workos.resources.audit_logs_export import WorkOSAuditLogsExport
 
 
 class _TestSetup:
@@ -150,7 +151,12 @@ class TestAuditLogs:
                 organization_id, range_start, range_end
             )
 
-            assert response == expected_payload
+            assert (
+                response.to_dict()
+                == WorkOSAuditLogsExport.construct_from_response(
+                    expected_payload
+                ).to_dict()
+            )
 
         def test_succeeds_with_additional_filters(self, mock_request_method):
             organization_id = "org_123456789"
@@ -174,13 +180,18 @@ class TestAuditLogs:
             response = self.audit_logs.create_export(
                 actions=actions,
                 actors=actors,
-                organization_id=organization_id,
+                organization=organization_id,
                 range_end=range_end,
                 range_start=range_start,
                 targets=targets,
             )
 
-            assert response == expected_payload
+            assert (
+                response.to_dict()
+                == WorkOSAuditLogsExport.construct_from_response(
+                    expected_payload
+                ).to_dict()
+            )
 
         def test_throws_unauthorized_excpetion(self, mock_request_method):
             organization_id = "org_123456789"
@@ -217,7 +228,12 @@ class TestAuditLogs:
                 expected_payload["id"],
             )
 
-            assert response == expected_payload
+            assert (
+                response.to_dict()
+                == WorkOSAuditLogsExport.construct_from_response(
+                    expected_payload
+                ).to_dict()
+            )
 
         def test_throws_unauthorized_excpetion(self, mock_request_method):
             mock_request_method(

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -7,7 +7,7 @@ import pytest
 import workos
 from workos.audit_logs import AuditLogs
 from workos.exceptions import AuthenticationException, BadRequestException
-from workos.resources.audit_logs_export import WorkOSAuditLogsExport
+from workos.resources.audit_logs_export import WorkOSAuditLogExport
 
 
 class _TestSetup:
@@ -153,7 +153,7 @@ class TestAuditLogs:
 
             assert (
                 response.to_dict()
-                == WorkOSAuditLogsExport.construct_from_response(
+                == WorkOSAuditLogExport.construct_from_response(
                     expected_payload
                 ).to_dict()
             )
@@ -188,7 +188,7 @@ class TestAuditLogs:
 
             assert (
                 response.to_dict()
-                == WorkOSAuditLogsExport.construct_from_response(
+                == WorkOSAuditLogExport.construct_from_response(
                     expected_payload
                 ).to_dict()
             )
@@ -230,7 +230,7 @@ class TestAuditLogs:
 
             assert (
                 response.to_dict()
-                == WorkOSAuditLogsExport.construct_from_response(
+                == WorkOSAuditLogExport.construct_from_response(
                     expected_payload
                 ).to_dict()
             )

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+import json
+from unittest.mock import Mock
+from requests import Response
+
+import pytest
+
+import workos
+from workos.audit_logs import AuditLogs
+from workos.exceptions import AuthenticationException, BadRequestException
+
+
+class TestAuditLogs(object):
+    @pytest.fixture(autouse=True)
+    def setup(self, set_api_key):
+        self.audit_logs = AuditLogs()
+
+    def test_create_audit_logs_event_succeeds(self, capture_and_mock_request):
+        organization_id = "org_123456789"
+
+        event = {
+            "action": 'document.updated',
+            "occurred_at": datetime.now().isoformat(),
+            "actor": {
+                "id": "user_1",
+                "name": "Jon Smith",
+                "type": "user",
+            },
+            "targets": [
+                {
+                    "id": 'document_39127',
+                    "type": 'document',
+                },
+            ],
+            "context": {
+                "location": "192.0.0.8",
+                "user_agent": "Firefox",
+            },
+            "metadata": {
+                "successful": True,
+            }
+        }
+        
+        _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
+
+        response = self.audit_logs.create_event(
+            organization_id, event, "test_123456")
+
+        assert request_kwargs["json"] == {"organization_id": organization_id, "event": event}
+        assert response == True
+
+    def test_create_audit_logs_event_sends_idempotency_key(self, capture_and_mock_request):
+        idempotency_key = "test_123456789"
+
+        organization_id = "org_123456789"
+
+        event = {
+            "action": 'document.updated',
+            "occurred_at": datetime.now().isoformat(),
+            "actor": {
+                "id": "user_1",
+                "name": "Jon Smith",
+                "type": "user",
+            },
+            "targets": [
+                {
+                    "id": 'document_39127',
+                    "type": 'document',
+                },
+            ],
+            "context": {
+                "location": "192.0.0.8",
+                "user_agent": "Firefox",
+            },
+            "metadata": {
+                "successful": True,
+            }
+        }
+        
+        _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
+
+        response = self.audit_logs.create_event(
+            organization_id, event, idempotency_key)
+
+        assert request_kwargs["headers"]["idempotency-key"] == idempotency_key
+        assert response == True
+
+
+    def test_create_audit_logs_event_throws_unauthorized_excpetion(self, capture_and_mock_request):
+            organization_id = "org_123456789"
+            event = {
+                "any_event": "event"
+            }
+            
+            _, request_kwargs = capture_and_mock_request("post", {"message": "Unauthorized"}, 401)
+            
+            with pytest.raises(AuthenticationException) as excinfo:
+                self.audit_logs.create_event(
+                    organization_id, event)
+            assert '(message=Unauthorized)' == str(excinfo.value)
+
+
+    def test_create_audit_logs_event_throws_badrequest_excpetion(self, mock_request_method):
+        organization_id = "org_123456789"
+        event = {
+            "any_event": "any_event"
+        }
+
+        mock_request_method("post", {"message": "Audit Log could not be processed due to missing or incorrect data.",
+                                     "code": "invalid_audit_log"}, 400)
+
+        with pytest.raises(BadRequestException) as excinfo:
+            self.audit_logs.create_event(
+                organization_id, event)
+        assert '(message=Audit Log could not be processed due to missing or incorrect data.)' == str(excinfo.value)

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -10,106 +10,238 @@ from workos.audit_logs import AuditLogs
 from workos.exceptions import AuthenticationException, BadRequestException
 
 
-class TestAuditLogs(object):
+class _TestSetup:
     @pytest.fixture(autouse=True)
     def setup(self, set_api_key):
         self.audit_logs = AuditLogs()
 
-    def test_create_audit_logs_event_succeeds(self, capture_and_mock_request):
-        organization_id = "org_123456789"
 
-        event = {
-            "action": 'document.updated',
-            "occurred_at": datetime.now().isoformat(),
-            "actor": {
-                "id": "user_1",
-                "name": "Jon Smith",
-                "type": "user",
-            },
-            "targets": [
-                {
-                    "id": 'document_39127',
-                    "type": 'document',
+class TestAuditLogs:
+    class TestCreateEvent(_TestSetup):
+        def test_succeeds(self, capture_and_mock_request):
+            organization_id = "org_123456789"
+
+            event = {
+                "action": 'document.updated',
+                "occurred_at": datetime.now().isoformat(),
+                "actor": {
+                    "id": "user_1",
+                    "name": "Jon Smith",
+                    "type": "user",
                 },
-            ],
-            "context": {
-                "location": "192.0.0.8",
-                "user_agent": "Firefox",
-            },
-            "metadata": {
-                "successful": True,
-            }
-        }
-        
-        _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
-
-        response = self.audit_logs.create_event(
-            organization_id, event, "test_123456")
-
-        assert request_kwargs["json"] == {"organization_id": organization_id, "event": event}
-        assert response == True
-
-    def test_create_audit_logs_event_sends_idempotency_key(self, capture_and_mock_request):
-        idempotency_key = "test_123456789"
-
-        organization_id = "org_123456789"
-
-        event = {
-            "action": 'document.updated',
-            "occurred_at": datetime.now().isoformat(),
-            "actor": {
-                "id": "user_1",
-                "name": "Jon Smith",
-                "type": "user",
-            },
-            "targets": [
-                {
-                    "id": 'document_39127',
-                    "type": 'document',
+                "targets": [
+                    {
+                        "id": 'document_39127',
+                        "type": 'document',
+                    },
+                ],
+                "context": {
+                    "location": "192.0.0.8",
+                    "user_agent": "Firefox",
                 },
-            ],
-            "context": {
-                "location": "192.0.0.8",
-                "user_agent": "Firefox",
-            },
-            "metadata": {
-                "successful": True,
+                "metadata": {
+                    "successful": True,
+                }
             }
-        }
-        
-        _, request_kwargs = capture_and_mock_request("post", {"success": True}, 200)
 
-        response = self.audit_logs.create_event(
-            organization_id, event, idempotency_key)
+            _, request_kwargs = capture_and_mock_request(
+                "post", {"success": True}, 200)
 
-        assert request_kwargs["headers"]["idempotency-key"] == idempotency_key
-        assert response == True
+            response = self.audit_logs.create_event(
+                organization_id, event, "test_123456")
 
+            assert request_kwargs["json"] == {
+                "organization_id": organization_id, "event": event}
+            assert response == True
 
-    def test_create_audit_logs_event_throws_unauthorized_excpetion(self, capture_and_mock_request):
+        def test_sends_idempotency_key(self, capture_and_mock_request):
+            idempotency_key = "test_123456789"
+
+            organization_id = "org_123456789"
+
+            event = {
+                "action": 'document.updated',
+                "occurred_at": datetime.now().isoformat(),
+                "actor": {
+                    "id": "user_1",
+                    "name": "Jon Smith",
+                    "type": "user",
+                },
+                "targets": [
+                    {
+                        "id": 'document_39127',
+                        "type": 'document',
+                    },
+                ],
+                "context": {
+                    "location": "192.0.0.8",
+                    "user_agent": "Firefox",
+                },
+                "metadata": {
+                    "successful": True,
+                }
+            }
+
+            _, request_kwargs = capture_and_mock_request(
+                "post",
+                {"success": True},
+                200
+            )
+
+            response = self.audit_logs.create_event(
+                organization_id, event, idempotency_key)
+
+            assert request_kwargs["headers"]["idempotency-key"] == idempotency_key
+            assert response == True
+
+        def test_throws_unauthorized_excpetion(self, mock_request_method):
             organization_id = "org_123456789"
             event = {
                 "any_event": "event"
             }
-            
-            _, request_kwargs = capture_and_mock_request("post", {"message": "Unauthorized"}, 401)
-            
+
+            mock_request_method(
+                "post",
+                {"message": "Unauthorized"},
+                401,
+                {"X-Request-ID": "a-request-id"}
+            )
+
             with pytest.raises(AuthenticationException) as excinfo:
                 self.audit_logs.create_event(
                     organization_id, event)
-            assert '(message=Unauthorized)' == str(excinfo.value)
+            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)
 
+        def test_throws_badrequest_excpetion(self, mock_request_method):
+            organization_id = "org_123456789"
+            event = {
+                "any_event": "any_event"
+            }
 
-    def test_create_audit_logs_event_throws_badrequest_excpetion(self, mock_request_method):
-        organization_id = "org_123456789"
-        event = {
-            "any_event": "any_event"
-        }
+            mock_request_method("post", {"message": "Audit Log could not be processed due to missing or incorrect data.",
+                                         "code": "invalid_audit_log"}, 400)
 
-        mock_request_method("post", {"message": "Audit Log could not be processed due to missing or incorrect data.",
-                                     "code": "invalid_audit_log"}, 400)
+            with pytest.raises(BadRequestException) as excinfo:
+                self.audit_logs.create_event(
+                    organization_id, event)
+            assert '(message=Audit Log could not be processed due to missing or incorrect data.)' == str(
+                excinfo.value)
 
-        with pytest.raises(BadRequestException) as excinfo:
-            self.audit_logs.create_event(
-                organization_id, event)
-        assert '(message=Audit Log could not be processed due to missing or incorrect data.)' == str(excinfo.value)
+    class TestCreateExport(_TestSetup):
+        def test_succeeds(self, mock_request_method):
+            organization_id = "org_123456789"
+            range_start = datetime.now().isoformat
+            range_end = datetime.now().isoformat
+
+            expected_payload = {
+                "object": 'audit_log_export',
+                "id": 'audit_log_export_1234',
+                "state": 'pending',
+                "url": None,
+                "created_at": datetime.now().isoformat,
+                "updated_at": datetime.now().isoformat,
+            }
+
+            mock_request_method(
+                "post",
+                expected_payload,
+                201
+            )
+
+            response = self.audit_logs.create_export(
+                organization_id,
+                range_start,
+                range_end
+            )
+
+            assert response == expected_payload
+
+        def test_succeeds_with_additional_filters(self, mock_request_method):
+            organization_id = "org_123456789"
+            range_start = datetime.now().isoformat
+            range_end = datetime.now().isoformat
+            actions = ['foo', 'bar']
+            actors = ['Jon', 'Smith']
+            targets = ['user', 'team']
+
+            expected_payload = {
+                "object": 'audit_log_export',
+                "id": 'audit_log_export_1234',
+                "state": 'pending',
+                "url": None,
+                "created_at": datetime.now().isoformat,
+                "updated_at": datetime.now().isoformat,
+            }
+
+            mock_request_method(
+                "post",
+                expected_payload,
+                201
+            )
+
+            response = self.audit_logs.create_export(
+                actions=actions,
+                actors=actors,
+                organization_id=organization_id,
+                range_end=range_end,
+                range_start=range_start,
+                targets=targets
+            )
+
+            assert response == expected_payload
+
+        def test_throws_unauthorized_excpetion(self, mock_request_method):
+            organization_id = "org_123456789"
+            range_start = datetime.now().isoformat
+            range_end = datetime.now().isoformat
+
+            mock_request_method(
+                "post",
+                {"message": "Unauthorized"},
+                401,
+                {"X-Request-ID": "a-request-id"}
+            )
+
+            with pytest.raises(AuthenticationException) as excinfo:
+                self.audit_logs.create_export(
+                    organization_id,
+                    range_start,
+                    range_end
+                )
+            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)
+
+    class TestGetExport(_TestSetup):
+        def test_succeeds(self, mock_request_method):
+            expected_payload = {
+                "object": 'audit_log_export',
+                "id": 'audit_log_export_1234',
+                "state": 'pending',
+                "url": None,
+                "created_at": datetime.now().isoformat,
+                "updated_at": datetime.now().isoformat,
+            }
+
+            mock_request_method(
+                "get",
+                expected_payload,
+                200
+            )
+
+            response = self.audit_logs.get_export(
+                expected_payload["id"],
+            )
+
+            assert response == expected_payload
+
+        def test_throws_unauthorized_excpetion(self, mock_request_method):
+            mock_request_method(
+                "get",
+                {"message": "Unauthorized"},
+                401,
+                {"X-Request-ID": "a-request-id"}
+            )
+
+            with pytest.raises(AuthenticationException) as excinfo:
+                self.audit_logs.get_export('audit_log_export_1234')
+
+            assert '(message=Unauthorized, request_id=a-request-id)' == str(excinfo.value)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ from workos.exceptions import ConfigurationException
 class TestClient(object):
     @pytest.fixture(autouse=True)
     def setup(self):
+        client._audit_logs = None
         client._audit_trail = None
         client._directory_sync = None
         client._organizations = None
@@ -17,8 +18,11 @@ class TestClient(object):
     def test_initialize_sso(self, set_api_key_and_client_id):
         assert bool(client.sso)
 
-    def test_initialize_audit_log(self, set_api_key):
+    def test_initialize_audit_trail(self, set_api_key):
         assert bool(client.audit_trail)
+
+    def test_initialize_audit_logs(self, set_api_key):
+        assert bool(client.audit_logs)
 
     def test_initialize_directory_sync(self, set_api_key):
         assert bool(client.directory_sync)

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -1,0 +1,66 @@
+import workos
+from workos.utils.pagiantion_order import Order
+from workos.exceptions import ConfigurationException
+from workos.resources.event import WorkOSEvent
+from workos.utils.request import RequestHelper, REQUEST_METHOD_GET, REQUEST_METHOD_POST
+from workos.utils.validation import AUDIT_TRAIL_MODULE, validate_settings
+
+EVENTS_PATH = "audit_logs/events"
+EXPORTS_PATH = "audit_logs/exports"
+
+
+class AuditLogs(object):
+    """Offers methods through the WorkOS Audit Logs service."""
+
+    @validate_settings(AUDIT_TRAIL_MODULE)
+    def __init__(self):
+        pass
+
+    @property
+    def request_helper(self):
+        if not getattr(self, "_request_helper", None):
+            self._request_helper = RequestHelper()
+        return self._request_helper
+
+    def create_event(self, organization_id, event, idempotency_key=None):
+        """Create an Audit Logs event.
+
+        Args:
+            organization_id (str) - Organization's unique identifier
+            event (dict) - An event object
+                event[action] (string) - The event action
+                event[version] (int) - The version of event
+                event[occurred_at] (datetime) - ISO-8601 datetime of when an event occurred
+                event[actor] (dict) - Describes the entity that generated the event
+                    event[actor][id] (str)
+                    event[actor][name] (str)
+                    event[actor][type] (str)
+                    event[actor][metadata] (dict)
+                event[targets] (list[dict])
+                event[context] (dict)
+                    event[context][location] (str)
+                    event[context][user_agent] (str)
+                event[metadata] (dict)
+            idempotency_key (str) - An idempotency key
+
+        Returns:
+            boolean: Returns True
+        """
+        payload = {
+            "organization_id": organization_id,
+            "event": event
+        }
+
+        headers = {}
+        if idempotency_key:
+            headers["idempotency-key"] = idempotency_key
+
+        response = self.request_helper.request(
+            EVENTS_PATH,
+            method=REQUEST_METHOD_POST,
+            params=payload,
+            headers=headers,
+            token=workos.api_key,
+        )
+
+        return response["success"]

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -36,20 +36,17 @@ class AuditLogs(object):
                     event[actor][name] (str)
                     event[actor][type] (str)
                     event[actor][metadata] (dict)
-                event[targets] (list[dict])
-                event[context] (dict)
+                event[targets] (list[dict]) - List of event targets
+                event[context] (dict) - Attributes of event context
                     event[context][location] (str)
                     event[context][user_agent] (str)
-                event[metadata] (dict)
-            idempotency_key (str) - An idempotency key
+                event[metadata] (dict) - Extra metadata
+            idempotency_key (str) - Optional idempotency key
 
         Returns:
             boolean: Returns True
         """
-        payload = {
-            "organization_id": organization_id,
-            "event": event
-        }
+        payload = {"organization_id": organization_id, "event": event}
 
         headers = {}
         if idempotency_key:
@@ -65,8 +62,28 @@ class AuditLogs(object):
 
         return response["success"]
 
-    def create_export(self, organization_id, range_start, range_end, actions=None, actors=None, targets=None):
-        """Create an export of logs."""
+    def create_export(
+        self,
+        organization_id,
+        range_start,
+        range_end,
+        actions=None,
+        actors=None,
+        targets=None,
+    ):
+        """Trigger the creation of an export of audit logs.
+        
+        Args:
+            organization_id (str) - Organization's unique identifier
+            range_start (str) - Start date of the range filter
+            range_end (str) - End date of the range filter
+            actions (list) - Optional list of actions to filter
+            actors (list) - Optional list of actors to filter
+            targets (list) - Optional list of targets to filter
+
+        Returns:
+            dict: Object that describes the exported audit logs job 
+        """
 
         payload = {
             "organization_id": organization_id,
@@ -91,7 +108,11 @@ class AuditLogs(object):
         )
 
     def get_export(self, export_id):
-        """Retrieve an created export."""
+        """Retrieve an created export.
+        
+        Returns:
+            dict: Object that describes the exported event
+        """
 
         return self.request_helper.request(
             "{0}/{1}".format(EVENTS_PATH, export_id),

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -83,7 +83,7 @@ class AuditLogs(object):
             targets (list) - Optional list of targets to filter
 
         Returns:
-            dict: Object that describes the exported audit logs job
+            dict: Object that describes the audit log export
         """
 
         payload = {

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -74,8 +74,8 @@ class AuditLogs(object):
 
         Args:
             organization (str) - Organization's unique identifier
-            range_start (str) - Start date of the range filter
-            range_end (str) - End date of the range filter
+            range_start (str) - Start date of the date range filter
+            range_end (str) - End date of the date range filter
             actions (list) - Optional list of actions to filter
             actors (list) - Optional list of actors to filter
             targets (list) - Optional list of targets to filter

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -61,8 +61,6 @@ class AuditLogs(object):
             token=workos.api_key,
         )
 
-        return response["success"]
-
     def create_export(
         self,
         organization,

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -72,7 +72,7 @@ class AuditLogs(object):
         targets=None,
     ):
         """Trigger the creation of an export of audit logs.
-        
+
         Args:
             organization_id (str) - Organization's unique identifier
             range_start (str) - Start date of the range filter
@@ -82,7 +82,7 @@ class AuditLogs(object):
             targets (list) - Optional list of targets to filter
 
         Returns:
-            dict: Object that describes the exported audit logs job 
+            dict: Object that describes the exported audit logs job
         """
 
         payload = {
@@ -109,7 +109,7 @@ class AuditLogs(object):
 
     def get_export(self, export_id):
         """Retrieve an created export.
-        
+
         Returns:
             dict: Object that describes the exported event
         """

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -30,7 +30,7 @@ class AuditLogs(object):
             organization (str) - Organization's unique identifier
             event (dict) - An event object
                 event[action] (string) - The event action
-                event[version] (int) - The version of event
+                event[version] (int) - The schema version of the event
                 event[occurred_at] (datetime) - ISO-8601 datetime of when an event occurred
                 event[actor] (dict) - Describes the entity that generated the event
                     event[actor][id] (str)

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -1,5 +1,5 @@
 import workos
-from workos.resources.audit_logs_export import WorkOSAuditLogsExport
+from workos.resources.audit_logs_export import WorkOSAuditLogExport
 from workos.utils.pagiantion_order import Order
 from workos.exceptions import ConfigurationException
 from workos.resources.event import WorkOSEvent
@@ -108,13 +108,13 @@ class AuditLogs(object):
             token=workos.api_key,
         )
 
-        return WorkOSAuditLogsExport.construct_from_response(response)
+        return WorkOSAuditLogExport.construct_from_response(response)
 
     def get_export(self, export_id):
         """Retrieve an created export.
 
         Returns:
-            dict: Object that describes the exported event
+            dict: Object that describes the audit log export
         """
 
         response = self.request_helper.request(
@@ -123,4 +123,4 @@ class AuditLogs(object):
             token=workos.api_key,
         )
 
-        return WorkOSAuditLogsExport.construct_from_response(response)
+        return WorkOSAuditLogExport.construct_from_response(response)

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -64,3 +64,37 @@ class AuditLogs(object):
         )
 
         return response["success"]
+
+    def create_export(self, organization_id, range_start, range_end, actions=None, actors=None, targets=None):
+        """Create an export of logs."""
+
+        payload = {
+            "organization_id": organization_id,
+            "range_start": range_start,
+            "range_end": range_end,
+        }
+
+        if actions:
+            payload["actions"] = actions
+
+        if actors:
+            payload["actors"] = actors
+
+        if actors:
+            payload["targets"] = targets
+
+        return self.request_helper.request(
+            EVENTS_PATH,
+            method=REQUEST_METHOD_POST,
+            params=payload,
+            token=workos.api_key,
+        )
+
+    def get_export(self, export_id):
+        """Retrieve an created export."""
+
+        return self.request_helper.request(
+            "{0}/{1}".format(EVENTS_PATH, export_id),
+            method=REQUEST_METHOD_GET,
+            token=workos.api_key,
+        )

--- a/workos/client.py
+++ b/workos/client.py
@@ -1,3 +1,4 @@
+from workos.audit_logs import AuditLogs
 from workos.audit_trail import AuditTrail
 from workos.directory_sync import DirectorySync
 from workos.organizations import Organizations
@@ -16,6 +17,12 @@ class Client(object):
         if not getattr(self, "_sso", None):
             self._sso = SSO()
         return self._sso
+
+    @property
+    def audit_logs(self):
+        if not getattr(self, "_audit_logs", None):
+            self._audit_logs = AuditLogs()
+        return self._audit_logs
 
     @property
     def audit_trail(self):

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -4,11 +4,21 @@ class ConfigurationException(Exception):
 
 # Request related exceptions
 class BaseRequestException(Exception):
-    def __init__(self, response, message=None, error=None, error_description=None):
+    def __init__(
+        self,
+        response,
+        message=None,
+        error=None,
+        errors=None,
+        error_description=None,
+        code=None,
+    ):
         super(BaseRequestException, self).__init__(message)
 
         self.message = message
         self.error = error
+        self.errors = errors
+        self.code = code
         self.error_description = error_description
         self.extract_and_set_response_related_data(response)
 
@@ -18,8 +28,12 @@ class BaseRequestException(Exception):
         try:
             response_json = response.json()
             self.message = response_json.get("message")
+            self.errors = response_json.get("errors")
+            self.code = response_json.get("code")
         except ValueError:
             self.message = None
+            self.errors = None
+            self.code = None
 
         headers = response.headers
         self.request_id = headers.get("X-Request-ID")
@@ -31,8 +45,14 @@ class BaseRequestException(Exception):
         if self.request_id is not None:
             exception += ", request_id=%s" % self.request_id
 
+        if self.code is not None:
+            exception += ", code=%s" % self.code
+
         if self.error is not None:
             exception += ", error=%s" % self.error
+
+        if self.errors is not None:
+            exception += ", errors=%s" % self.errors
 
         if self.error_description is not None:
             exception += ", error_description=%s" % self.error_description

--- a/workos/resources/audit_logs_export.py
+++ b/workos/resources/audit_logs_export.py
@@ -1,0 +1,28 @@
+from workos.resources.base import WorkOSBaseResource
+from workos.resources.event_action import WorkOSEventAction
+
+
+class WorkOSAuditLogsExport(WorkOSBaseResource):
+    """Representation of an export as returned by WorkOS through the Audit Logs Create/Get Export feature.
+
+    Attributes:
+        OBJECT_FIELDS (list): List of fields a WorkOSAuditLogsEvent is comprised of.
+    """
+
+    OBJECT_FIELDS = [
+        "id",
+        "object",
+        "state",
+        "url",
+        "created_at",
+        "updated_at",
+    ]
+
+    @classmethod
+    def construct_from_response(cls, response):
+        export = super(WorkOSAuditLogsExport, cls).construct_from_response(response)
+        return export
+
+    def to_dict(self):
+        export_dict = super(WorkOSAuditLogsExport, self).to_dict()
+        return export_dict

--- a/workos/resources/audit_logs_export.py
+++ b/workos/resources/audit_logs_export.py
@@ -2,7 +2,7 @@ from workos.resources.base import WorkOSBaseResource
 from workos.resources.event_action import WorkOSEventAction
 
 
-class WorkOSAuditLogsExport(WorkOSBaseResource):
+class WorkOSAuditLogExport(WorkOSBaseResource):
     """Representation of an export as returned by WorkOS through the Audit Logs Create/Get Export feature.
 
     Attributes:
@@ -20,9 +20,9 @@ class WorkOSAuditLogsExport(WorkOSBaseResource):
 
     @classmethod
     def construct_from_response(cls, response):
-        export = super(WorkOSAuditLogsExport, cls).construct_from_response(response)
+        export = super(WorkOSAuditLogExport, cls).construct_from_response(response)
         return export
 
     def to_dict(self):
-        export_dict = super(WorkOSAuditLogsExport, self).to_dict()
+        export_dict = super(WorkOSAuditLogExport, self).to_dict()
         return export_dict

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -55,7 +55,7 @@ class RequestHelper(object):
 
         Kwargs:
             method (str): One of the supported methods as defined by the REQUEST_METHOD_X constants
-            params (dict): Query params to be added to the request
+            params (dict): Query params or body payload to be added to the request
             token (str): Bearer token
 
         Returns:


### PR DESCRIPTION
Add AuditLogs calls to the SDK:
-  `create_event`
-  `create_export`
-  `get_export`

Also made a few tweaks to expose `code` and `errors` payload in exceptions.