### PR TITLE
Add groups attribute to SSO user profile

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -28,6 +28,7 @@ class TestSSO(object):
             "email": "demo@workos-okta.com",
             "first_name": "WorkOS",
             "last_name": "Demo",
+            "groups": ["Admins", "Developers"],
             "organization_id": "org_01FG53X8636WSNW2WEKB2C31ZB",
             "connection_id": "conn_01EMH8WAK20T42N2NBMNBCYHAG",
             "connection_type": "OktaSAML",
@@ -36,6 +37,7 @@ class TestSSO(object):
                 "email": "demo@workos-okta.com",
                 "first_name": "WorkOS",
                 "last_name": "Demo",
+                "groups": ["Admins", "Developers"],
             },
         }
 
@@ -50,6 +52,7 @@ class TestSSO(object):
             "idp_id": "",
             "first_name": None,
             "last_name": None,
+            "groups": None,
             "raw_attributes": {},
         }
 
@@ -317,6 +320,7 @@ class TestSSO(object):
                 "id": mock_profile["id"],
                 "email": mock_profile["email"],
                 "first_name": mock_profile["first_name"],
+                "groups": mock_profile["groups"],
                 "organization_id": mock_profile["organization_id"],
                 "connection_id": mock_profile["connection_id"],
                 "connection_type": mock_profile["connection_type"],
@@ -326,6 +330,7 @@ class TestSSO(object):
                     "email": mock_profile["raw_attributes"]["email"],
                     "first_name": mock_profile["raw_attributes"]["first_name"],
                     "last_name": mock_profile["raw_attributes"]["last_name"],
+                    "groups": mock_profile["raw_attributes"]["groups"],
                 },
             },
             "access_token": "01DY34ACQTM3B1CSX1YSZ8Z00D",

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -13,6 +13,7 @@ class WorkOSProfile(WorkOSBaseResource):
         "email",
         "first_name",
         "last_name",
+        "groups",
         "organization_id",
         "connection_id",
         "connection_type",


### PR DESCRIPTION
## Description

Adds new groups attribute to SSO user profile.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.