### PR TITLE
Add `actor_names` and `actor_ids` to `create_export`

### DIFF
--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -167,6 +167,8 @@ class TestAuditLogs:
             range_end = datetime.now().isoformat
             actions = ["foo", "bar"]
             actors = ["Jon", "Smith"]
+            actor_names = ["Jon", "Smith"]
+            actor_ids = ["user_foo", "user_bar"]
             targets = ["user", "team"]
 
             expected_payload = {
@@ -187,6 +189,8 @@ class TestAuditLogs:
                 range_end=range_end,
                 range_start=range_start,
                 targets=targets,
+                actor_names=actor_names,
+                actor_ids=actor_ids,
             )
 
             assert (

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -1,3 +1,4 @@
+from warnings import warn
 import workos
 from workos.resources.audit_logs_export import WorkOSAuditLogExport
 from workos.utils.request import RequestHelper, REQUEST_METHOD_GET, REQUEST_METHOD_POST
@@ -66,6 +67,8 @@ class AuditLogs(object):
         actions=None,
         actors=None,
         targets=None,
+        actor_names=None,
+        actor_ids=None,
     ):
         """Trigger the creation of an export of audit logs.
 
@@ -92,8 +95,18 @@ class AuditLogs(object):
 
         if actors:
             payload["actors"] = actors
+            warn(
+                "The 'actors' parameter is deprecated. Please use 'actor_names' instead.",
+                DeprecationWarning,
+            )
 
-        if actors:
+        if actor_names:
+            payload["actor_names"] = actor_names
+
+        if actor_ids:
+            payload["actor_ids"] = actor_ids
+
+        if targets:
             payload["targets"] = targets
 
         response = self.request_helper.request(


### PR DESCRIPTION
## Description

- Adds `actor_names` and `actor_ids` to `create_export`
- Deprecates `actors` in favor of `actor_names`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.