### PR TITLE
Update default limit check for list methods

### DIFF
--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -93,7 +93,10 @@ class DirectorySync(WorkOSListResource):
         )
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         response["metadata"] = {
             "params": params,
@@ -159,7 +162,10 @@ class DirectorySync(WorkOSListResource):
         )
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         response["metadata"] = {
             "params": params,
@@ -222,7 +228,10 @@ class DirectorySync(WorkOSListResource):
         )
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         response["metadata"] = {
             "params": params,
@@ -281,7 +290,10 @@ class DirectorySync(WorkOSListResource):
         )
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         response["metadata"] = {
             "params": params,
@@ -408,7 +420,10 @@ class DirectorySync(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return response
 
@@ -473,7 +488,10 @@ class DirectorySync(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return self.construct_from_response(response)
 

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -85,7 +85,10 @@ class Organizations(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return response
 
@@ -146,7 +149,10 @@ class Organizations(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            dict_response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in dict_response and "params" in dict_response["metadata"]:
+                dict_response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                dict_response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return self.construct_from_response(dict_response)
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -269,7 +269,10 @@ class SSO(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return response
 
@@ -349,7 +352,10 @@ class SSO(WorkOSListResource):
         }
 
         if "default_limit" in locals():
-            response["metadata"]["params"]["default_limit"] = default_limit
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
 
         return self.construct_from_response(response)
 


### PR DESCRIPTION
## Description
Update default limit check for list methods. This resolves the bug where you receive an error on calling a list method with the default limit set. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.