### PR TITLE
Feature/pin dependency versions for deployment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ if sys.version_info.major == 3:
             "black==22.3.0",
             "twine==3.1.1",
             "requests==2.29.0",
-            "requests-toolbelt==0.9.0"
-            "urllib3==2.0.2",
+            "requests-toolbelt==0.9.0",            
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ if sys.version_info.major == 3:
         [
             "black==22.3.0",
             "twine==3.1.1",
-            "requests==2.30.0",
+            "requests==2.29.0",
+            "requests-toolbelt==0.9.0"
             "urllib3==2.0.2",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ if sys.version_info.major == 3:
     dev_requirements.extend(
         [
             "black==22.3.0",
-            "twine==3.1.1",
-            "requests==2.29.0",
-            "requests-toolbelt==0.9.0",            
+            "twine==4.0.2",
+            "requests==2.30.0",
+            "urllib3==2.0.2",            
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info.major == 3:
             "black==22.3.0",
             "twine==4.0.2",
             "requests==2.30.0",
-            "urllib3==2.0.2",            
+            "urllib3==2.0.2",
         ]
     )
 


### PR DESCRIPTION
## Description
Pin newest versions of twine, requests, and urllib3 dependencies.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.