### PR TITLE
Add method to `get_events` from `Events` service

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,45 @@
+import pytest
+from workos.events import Events
+from tests.utils.fixtures.mock_event import MockEvent
+
+
+class TestEvents(object):
+    @pytest.fixture(autouse=True)
+    def setup(self, set_api_key, set_client_id):
+        self.events = Events()
+
+    @pytest.fixture
+    def mock_events(self):
+        events = [MockEvent(id=str(i)).to_dict() for i in range(100)]
+
+        return {
+            "data": events,
+            "list_metadata": {"after": None},
+            "metadata": {
+                "params": {
+                    "events": None,
+                    "limit": None,
+                    "after": None,
+                    "rangeStart": None,
+                    "rangeEnd": None,
+                    "default_limit": True,
+                },
+                "method": Events.get_events,
+            },
+        }
+
+    def test_get_events(self, mock_events, mock_request_method):
+        mock_request_method("get", mock_events, 200)
+
+        events = self.events.get_events()
+
+        assert events == mock_events
+
+    def test_get_events_returns_metadata(self, mock_events, mock_request_method):
+        mock_request_method("get", mock_events, 200)
+
+        events = self.events.get_events(
+            events=["dsync.user.created"],
+        )
+
+        assert events["metadata"]["params"]["events"] == ["dsync.user.created"]

--- a/tests/utils/fixtures/mock_event.py
+++ b/tests/utils/fixtures/mock_event.py
@@ -1,0 +1,21 @@
+import datetime
+from workos.resources.base import WorkOSBaseResource
+
+
+class MockEvent(WorkOSBaseResource):
+    def __init__(self, id):
+        self.object = "event"
+        self.id = id
+        self.event = "dsync.user.created"
+        self.data = {
+            "id": "event_01234ABCD",
+        }
+        self.created_at = datetime.datetime.now()
+
+    OBJECT_FIELDS = [
+        "object",
+        "id",
+        "event",
+        "data",
+        "created_at",
+    ]

--- a/workos/client.py
+++ b/workos/client.py
@@ -40,8 +40,8 @@ class Client(object):
     @property
     def events(self):
         if not getattr(self, "_events", None):
-            self._directory_sync = Events()
-        return self._directory_sync
+            self.events = Events()
+        return self._events
 
     @property
     def organizations(self):

--- a/workos/client.py
+++ b/workos/client.py
@@ -7,6 +7,7 @@ from workos.portal import Portal
 from workos.sso import SSO
 from workos.webhooks import Webhooks
 from workos.mfa import Mfa
+from workos.events import Events
 
 
 class Client(object):
@@ -34,6 +35,12 @@ class Client(object):
     def directory_sync(self):
         if not getattr(self, "_directory_sync", None):
             self._directory_sync = DirectorySync()
+        return self._directory_sync
+
+    @property
+    def events(self):
+        if not getattr(self, "_events", None):
+            self._directory_sync = Events()
         return self._directory_sync
 
     @property

--- a/workos/client.py
+++ b/workos/client.py
@@ -40,7 +40,7 @@ class Client(object):
     @property
     def events(self):
         if not getattr(self, "_events", None):
-            self.events = Events()
+            self._events = Events()
         return self._events
 
     @property

--- a/workos/events.py
+++ b/workos/events.py
@@ -33,12 +33,12 @@ class Events(WorkOSListResource):
         rangeEnd=None,
     ):
         """Gets a list of Events .
-        Args:
-            events (list): Filter to only return events of particular types.
-            limit (int): Maximum number of records to return.
-            after (str): Pagination cursor to receive records after a provided Event ID.
-            rangeStart (str): Date range start for stream of events.
-            rangeEnd (str): Date range end for stream of events.
+        Kwargs:
+            events (list): Filter to only return events of particular types. (Optional)
+            limit (int): Maximum number of records to return. (Optional)
+            after (str): Pagination cursor to receive records after a provided Event ID. (Optional)
+            rangeStart (str): Date range start for stream of events. (Optional)
+            rangeEnd (str): Date range end for stream of events. (Optional)
 
 
         Returns:

--- a/workos/events.py
+++ b/workos/events.py
@@ -34,7 +34,7 @@ class Events(WorkOSListResource):
     ):
         """Gets a list of Events .
         Args:
-            events (str): Event type.
+            events (list): Filter to only return events of particular types.
             limit (int): Maximum number of records to return.
             after (str): Pagination cursor to receive records after a provided Event ID.
             rangeStart (str): Date range start for stream of events.
@@ -44,7 +44,6 @@ class Events(WorkOSListResource):
         Returns:
             dict: Events response from WorkOS.
         """
-
         if limit is None:
             limit = RESPONSE_LIMIT
             default_limit = True

--- a/workos/events.py
+++ b/workos/events.py
@@ -58,7 +58,7 @@ class Events(WorkOSListResource):
         }
 
         response = self.request_helper.request(
-            "canonical_events",
+            "events",
             method=REQUEST_METHOD_GET,
             params=params,
             token=workos.api_key,

--- a/workos/events.py
+++ b/workos/events.py
@@ -44,6 +44,7 @@ class Events(WorkOSListResource):
         Returns:
             dict: Events response from WorkOS.
         """
+
         if limit is None:
             limit = RESPONSE_LIMIT
             default_limit = True

--- a/workos/events.py
+++ b/workos/events.py
@@ -1,0 +1,78 @@
+from warnings import warn
+import workos
+from workos.utils.request import (
+    RequestHelper,
+    REQUEST_METHOD_GET,
+)
+
+from workos.utils.validation import EVENTS_MODULE, validate_settings
+from workos.resources.list import WorkOSListResource
+
+RESPONSE_LIMIT = 10
+
+
+class Events(WorkOSListResource):
+    """Offers methods through the WorkOS Events service."""
+
+    @validate_settings(EVENTS_MODULE)
+    def __init__(self):
+        pass
+
+    @property
+    def request_helper(self):
+        if not getattr(self, "_request_helper", None):
+            self._request_helper = RequestHelper()
+        return self._request_helper
+
+    def get_events(
+        self,
+        events=None,
+        limit=None,
+        after=None,
+        rangeStart=None,
+        rangeEnd=None,
+    ):
+        """Gets a list of Events .
+        Args:
+            events (str): Event type.
+            limit (int): Maximum number of records to return.
+            after (str): Pagination cursor to receive records after a provided Event ID.
+            rangeStart (str): Date range start for stream of events.
+            rangeEnd (str): Date range end for stream of events.
+
+
+        Returns:
+            dict: Events response from WorkOS.
+        """
+
+        if limit is None:
+            limit = RESPONSE_LIMIT
+            default_limit = True
+
+        params = {
+            "events": events,
+            "limit": limit,
+            "after": after,
+            "rangeStart": rangeStart,
+            "rangeEnd": rangeEnd,
+        }
+
+        response = self.request_helper.request(
+            "canonical_events",
+            method=REQUEST_METHOD_GET,
+            params=params,
+            token=workos.api_key,
+        )
+
+        if "default_limit" in locals():
+            if "metadata" in response and "params" in response["metadata"]:
+                response["metadata"]["params"]["default_limit"] = default_limit
+            else:
+                response["metadata"] = {"params": {"default_limit": default_limit}}
+
+        response["metadata"] = {
+            "params": params,
+            "method": Events.get_events,
+        }
+
+        return response

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -6,6 +6,7 @@ from workos.exceptions import ConfigurationException
 AUDIT_LOGS_MODULE = "AuditLogs"
 AUDIT_TRAIL_MODULE = "AuditTrail"
 DIRECTORY_SYNC_MODULE = "DirectorySync"
+EVENTS_MODULE = "Events"
 ORGANIZATIONS_MODULE = "Organizations"
 PASSWORDLESS_MODULE = "Passwordless"
 PORTAL_MODULE = "Portal"
@@ -21,6 +22,9 @@ REQUIRED_SETTINGS_FOR_MODULE = {
         "api_key",
     ],
     DIRECTORY_SYNC_MODULE: [
+        "api_key",
+    ],
+    EVENTS_MODULE: [
         "api_key",
     ],
     ORGANIZATIONS_MODULE: [


### PR DESCRIPTION
## Description
Add support to get a list of events from the `Events` service. Introduces a new module for `Events`, and the corresponding endpoint. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.