### PR TITLE
Update `get_events` to `list_events`

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -24,21 +24,21 @@ class TestEvents(object):
                     "rangeEnd": None,
                     "default_limit": True,
                 },
-                "method": Events.get_events,
+                "method": Events.list_events,
             },
         }
 
-    def test_get_events(self, mock_events, mock_request_method):
+    def test_list_events(self, mock_events, mock_request_method):
         mock_request_method("get", mock_events, 200)
 
-        events = self.events.get_events()
+        events = self.events.list_events()
 
         assert events == mock_events
 
-    def test_get_events_returns_metadata(self, mock_events, mock_request_method):
+    def test_list_events_returns_metadata(self, mock_events, mock_request_method):
         mock_request_method("get", mock_events, 200)
 
-        events = self.events.get_events(
+        events = self.events.list_events(
             events=["dsync.user.created"],
         )
 

--- a/workos/events.py
+++ b/workos/events.py
@@ -24,7 +24,7 @@ class Events(WorkOSListResource):
             self._request_helper = RequestHelper()
         return self._request_helper
 
-    def get_events(
+    def list_events(
         self,
         events=None,
         limit=None,
@@ -72,7 +72,7 @@ class Events(WorkOSListResource):
 
         response["metadata"] = {
             "params": params,
-            "method": Events.get_events,
+            "method": Events.list_events,
         }
 
         return response


### PR DESCRIPTION
## Description

More cohesive with the other `list_X` API methods 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.