### PR TITLE
Add `format` script to Devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -11,6 +11,7 @@
       "pip install -e .[dev]"
     ],
     "scripts": {
+      "format": "black .",
       "test": "python -m pytest"
     }
   }


### PR DESCRIPTION
## Description

This PR adds a `format` script to Devbox for formatting code with Black.

```
devbox run format
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.