### PR TITLE
Remove `domains` and `allowProfilesOutsideOrganization` from Organization entity

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -18,14 +18,6 @@ class TestOrganizations(object):
             "name": "Example Organization",
             "object": "organization",
             "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
-            "allow_profiles_outside_organization": True,
-            "domains": [
-                {
-                    "domain": "example.io",
-                    "object": "organization_domain",
-                    "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8",
-                }
-            ],
         }
 
     @pytest.fixture
@@ -188,7 +180,7 @@ class TestOrganizations(object):
     def test_create_organization(self, mock_organization, mock_request_method):
         mock_request_method("post", mock_organization, 201)
 
-        payload = {"domains": ["example.com"], "name": "Test Organization"}
+        payload = {"name": "Test Organization"}
         organization = self.organizations.create_organization(payload)
 
         assert organization["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
@@ -196,7 +188,7 @@ class TestOrganizations(object):
 
     def test_sends_idempotency_key(self, capture_and_mock_request):
         idempotency_key = "test_123456789"
-        payload = {"domains": ["example.com"], "name": "Foo Corporation"}
+        payload = {"name": "Foo Corporation"}
 
         _, request_kwargs = capture_and_mock_request("post", payload, 200)
 
@@ -213,20 +205,10 @@ class TestOrganizations(object):
         updated_organization = self.organizations.update_organization(
             organization="org_01EHT88Z8J8795GZNQ4ZP1J81T",
             name="Example Organization",
-            domains=["example.io"],
-            allow_profiles_outside_organization=True,
         )
 
         assert updated_organization["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
         assert updated_organization["name"] == "Example Organization"
-        assert updated_organization["domains"] == [
-            {
-                "domain": "example.io",
-                "object": "organization_domain",
-                "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8",
-            }
-        ]
-        assert updated_organization["allow_profiles_outside_organization"]
 
     def test_delete_organization(self, setup, mock_raw_request_method):
         mock_raw_request_method(

--- a/tests/utils/fixtures/mock_organization.py
+++ b/tests/utils/fixtures/mock_organization.py
@@ -7,17 +7,13 @@ class MockOrganization(WorkOSBaseResource):
         self.id = id
         self.object = "organization"
         self.name = "Foo Corporation"
-        self.allow_profiles_outside_organization = False
         self.created_at = datetime.datetime.now()
         self.updated_at = datetime.datetime.now()
-        self.domains = ["domain1.com"]
 
     OBJECT_FIELDS = [
         "id",
         "object",
         "name",
-        "allow_profiles_outside_organization",
         "created_at",
         "updated_at",
-        "domains",
     ]

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -175,10 +175,6 @@ class Organizations(WorkOSListResource):
         Args:
             organization (dict) - An organization object
                 organization[name] (str) - A unique, descriptive name for the organization
-                organization[allow_profiles_outside_organization] (boolean) - Whether Connections
-                    within the Organization allow profiles that are outside of the Organization's
-                    configured User Email Domains. (Optional)
-                organization[domains] (list) - List of domains that belong to the organization
             idempotency_key (str) - Idempotency key for creating an organization. (Optional)
 
         Returns:
@@ -199,25 +195,19 @@ class Organizations(WorkOSListResource):
         return WorkOSOrganization.construct_from_response(response).to_dict()
 
     def update_organization(
-        self, organization, name, allow_profiles_outside_organization=None, domains=None
+        self, organization, name
     ):
         """Update an organization
 
         Args:
             organization(str) - Organization's unique identifier.
             name (str) - A unique, descriptive name for the organization.
-            allow_profiles_outside_organization (boolean) - Whether Connections
-                within the Organization allow profiles that are outside of the Organization's
-                configured User Email Domains. (Optional)
-            domains (list) - List of domains that belong to the organization. (Optional)
 
         Returns:
             dict: Updated Organization response from WorkOS.
         """
         params = {
             "name": name,
-            "domains": domains,
-            "allow_profiles_outside_organization": allow_profiles_outside_organization,
         }
         response = self.request_helper.request(
             "organizations/{organization}".format(organization=organization),

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -194,9 +194,7 @@ class Organizations(WorkOSListResource):
 
         return WorkOSOrganization.construct_from_response(response).to_dict()
 
-    def update_organization(
-        self, organization, name
-    ):
+    def update_organization(self, organization, name):
         """Update an organization
 
         Args:

--- a/workos/resources/organizations.py
+++ b/workos/resources/organizations.py
@@ -12,10 +12,8 @@ class WorkOSOrganization(WorkOSBaseResource):
         "id",
         "object",
         "name",
-        "allow_profiles_outside_organization",
         "created_at",
         "updated_at",
-        "domains",
     ]
 
     @classmethod


### PR DESCRIPTION
## Description

Breaking change. Removes domains and allowProfilesOutsideOrganization from Organization entity

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.