### PR TITLE
Rename Users to UserManagement

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ class TestClient(object):
         client._passwordless = None
         client._portal = None
         client._sso = None
-        client._users = None
+        client._user_management = None
 
     def test_initialize_sso(self, set_api_key_and_client_id):
         assert bool(client.sso)
@@ -37,8 +37,8 @@ class TestClient(object):
     def test_initialize_portal(self, set_api_key):
         assert bool(client.portal)
 
-    def test_initialize_users(self, set_api_key, set_client_id):
-        assert bool(client.users)
+    def test_initialize_user_management(self, set_api_key, set_client_id):
+        assert bool(client.user_management)
 
     def test_initialize_sso_missing_api_key(self, set_client_id):
         with pytest.raises(ConfigurationException) as ex:
@@ -112,25 +112,25 @@ class TestClient(object):
 
         assert "api_key" in message
 
-    def test_initialize_users_missing_client_id(self, set_api_key):
+    def test_initialize_user_management_missing_client_id(self, set_api_key):
         with pytest.raises(ConfigurationException) as ex:
-            client.users
+            client.user_management
 
         message = str(ex)
 
         assert "client_id" in message
 
-    def test_initialize_users_missing_api_key(self, set_client_id):
+    def test_initialize_user_management_missing_api_key(self, set_client_id):
         with pytest.raises(ConfigurationException) as ex:
-            client.users
+            client.user_management
 
         message = str(ex)
 
         assert "api_key" in message
 
-    def test_initialize_users_missing_api_key_and_client_id(self):
+    def test_initialize_user_management_missing_api_key_and_client_id(self):
         with pytest.raises(ConfigurationException) as ex:
-            client.users
+            client.user_management
 
         message = str(ex)
 

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -2,13 +2,13 @@ import pytest
 
 from tests.utils.fixtures.mock_session import MockSession
 from tests.utils.fixtures.mock_user import MockUser
-from workos.users import Users
+from workos.user_management import UserManagement
 
 
-class TestUsers(object):
+class TestUserManagement(object):
     @pytest.fixture(autouse=True)
     def setup(self, set_api_key, set_client_id):
-        self.users = Users()
+        self.user_management = UserManagement()
 
     @pytest.fixture
     def mock_user(self):
@@ -31,7 +31,7 @@ class TestUsers(object):
                     "order": None,
                     "default_limit": True,
                 },
-                "method": Users.list_users,
+                "method": UserManagement.list_users,
             },
         }
         return dict_response
@@ -52,10 +52,10 @@ class TestUsers(object):
                     "after": None,
                     "order": None,
                 },
-                "method": Users.list_users,
+                "method": UserManagement.list_users,
             },
         }
-        return self.users.construct_from_response(dict_response)
+        return self.user_management.construct_from_response(dict_response)
 
     @pytest.fixture
     def mock_users_with_default_limit(self):
@@ -75,10 +75,10 @@ class TestUsers(object):
                     "order": None,
                     "default_limit": True,
                 },
-                "method": Users.list_users,
+                "method": UserManagement.list_users,
             },
         }
-        return self.users.construct_from_response(dict_response)
+        return self.user_management.construct_from_response(dict_response)
 
     @pytest.fixture
     def mock_users_pagination_response(self):
@@ -96,7 +96,7 @@ class TestUsers(object):
                     "order": None,
                     "default_limit": True,
                 },
-                "method": Users.list_users,
+                "method": UserManagement.list_users,
             },
         }
 
@@ -134,14 +134,14 @@ class TestUsers(object):
             "password": "password",
             "email_verified": False,
         }
-        user = self.users.create_user(payload)
+        user = self.user_management.create_user(payload)
 
         assert user["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
 
     def test_get_user(self, mock_user, capture_and_mock_request):
         url, request_kwargs = capture_and_mock_request("get", mock_user, 200)
 
-        user = self.users.get_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
+        user = self.user_management.get_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
 
         assert url[0].endswith("users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
         assert user["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
@@ -177,7 +177,7 @@ class TestUsers(object):
     ):
         mock_request_method("get", mock_users, 200)
 
-        users = self.users.list_users(
+        users = self.user_management.list_users(
             email="marcelina@foo-corp.com",
             organization="foo-corp.com",
         )
@@ -189,7 +189,7 @@ class TestUsers(object):
     def test_delete_user(self, capture_and_mock_request):
         url, request_kwargs = capture_and_mock_request("delete", None, 200)
 
-        user = self.users.delete_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
+        user = self.user_management.delete_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
 
         assert url[0].endswith("users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
         assert user is None
@@ -197,7 +197,7 @@ class TestUsers(object):
     def test_update_user(self, mock_user, capture_and_mock_request):
         url, request = capture_and_mock_request("put", mock_user, 200)
 
-        user = self.users.update_user(
+        user = self.user_management.update_user(
             "user_01H7ZGXFP5C6BBQY6Z7277ZCT0",
             {
                 "first_name": "Marcelina",
@@ -215,7 +215,7 @@ class TestUsers(object):
     def test_update_user_password(self, mock_user, capture_and_mock_request):
         url, request = capture_and_mock_request("put", mock_user, 200)
 
-        user = self.users.update_user_password(
+        user = self.user_management.update_user_password(
             "user_01H7ZGXFP5C6BBQY6Z7277ZCT0", "pass_123"
         )
 
@@ -226,7 +226,7 @@ class TestUsers(object):
     def test_add_user_to_organization(self, capture_and_mock_request, mock_user):
         url, _ = capture_and_mock_request("post", mock_user, 200)
 
-        user = self.users.add_user_to_organization("user_123", "org_123")
+        user = self.user_management.add_user_to_organization("user_123", "org_123")
 
         assert url[0].endswith("users/user_123/organization/org_123")
         assert user["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
@@ -234,7 +234,7 @@ class TestUsers(object):
     def test_remove_user_from_organization(self, capture_and_mock_request, mock_user):
         url, _ = capture_and_mock_request("delete", mock_user, 200)
 
-        user = self.users.remove_user_from_organization("user_123", "org_123")
+        user = self.user_management.remove_user_from_organization("user_123", "org_123")
 
         assert url[0].endswith("users/user_123/organization/org_123")
         assert user["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
@@ -249,7 +249,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_auth_response, 200)
 
-        response = self.users.authenticate_with_magic_auth(
+        response = self.user_management.authenticate_with_magic_auth(
             code=code,
             user=user,
             user_agent=user_agent,
@@ -279,7 +279,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_auth_response, 200)
 
-        response = self.users.authenticate_with_password(
+        response = self.user_management.authenticate_with_password(
             email=email,
             password=password,
             user_agent=user_agent,
@@ -303,7 +303,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_auth_response, 200)
 
-        response = self.users.authenticate_with_code(
+        response = self.user_management.authenticate_with_code(
             code=code,
             user_agent=user_agent,
             ip_address=ip_address,
@@ -328,7 +328,7 @@ class TestUsers(object):
             "post", mock_password_challenge_response, 200
         )
 
-        response = self.users.create_password_reset_challenge(
+        response = self.user_management.create_password_reset_challenge(
             email=email,
             password_reset_url=password_reset_url,
         )
@@ -345,7 +345,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_user, 200)
 
-        response = self.users.complete_password_reset(
+        response = self.user_management.complete_password_reset(
             token=token,
             new_password=new_password,
         )
@@ -360,7 +360,7 @@ class TestUsers(object):
 
         url, _ = capture_and_mock_request("post", mock_user, 200)
 
-        response = self.users.send_verification_email(user=user)
+        response = self.user_management.send_verification_email(user=user)
 
         assert url[0].endswith(
             "users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0/send_verification_email"
@@ -373,7 +373,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_auth_response, 200)
 
-        response = self.users.verify_email_code(user=user, code=code)
+        response = self.user_management.verify_email_code(user=user, code=code)
 
         assert url[0].endswith("users/verify_email_code")
         assert request["json"]["user_id"] == user
@@ -385,7 +385,7 @@ class TestUsers(object):
 
         url, request = capture_and_mock_request("post", mock_user, 200)
 
-        response = self.users.send_magic_auth_code(email=email)
+        response = self.user_management.send_magic_auth_code(email=email)
 
         assert url[0].endswith("users/magic_auth/send")
         assert request["json"]["email_address"] == email

--- a/workos/client.py
+++ b/workos/client.py
@@ -8,7 +8,7 @@ from workos.sso import SSO
 from workos.webhooks import Webhooks
 from workos.mfa import Mfa
 from workos.events import Events
-from workos.users import Users
+from workos.user_management import UserManagement
 
 
 class Client(object):
@@ -75,10 +75,10 @@ class Client(object):
         return self._mfa
 
     @property
-    def users(self):
-        if not getattr(self, "_users", None):
-            self._users = Users()
-        return self._users
+    def user_management(self):
+        if not getattr(self, "_user_management", None):
+            self._user_management = UserManagement()
+        return self._user_management
 
 
 client = Client()

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -13,7 +13,7 @@ from workos.utils.request import (
     REQUEST_METHOD_DELETE,
     REQUEST_METHOD_PUT,
 )
-from workos.utils.validation import validate_settings, USERS_MODULE
+from workos.utils.validation import validate_settings, USER_MANAGEMENT_MODULE
 
 USER_PATH = "users"
 USER_DETAIL_PATH = "users/{0}"
@@ -29,10 +29,10 @@ USER_SEND_MAGIC_AUTH_PATH = "users/magic_auth/send"
 RESPONSE_LIMIT = 10
 
 
-class Users(WorkOSListResource):
+class UserManagement(WorkOSListResource):
     """Offers methods for using the WorkOS User Management API."""
 
-    @validate_settings(USERS_MODULE)
+    @validate_settings(USER_MANAGEMENT_MODULE)
     def __init__(self):
         pass
 
@@ -141,7 +141,7 @@ class Users(WorkOSListResource):
 
         response["metadata"] = {
             "params": params,
-            "method": Users.list_users,
+            "method": UserManagement.list_users,
         }
 
         if "default_limit" in locals():

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -13,7 +13,7 @@ PORTAL_MODULE = "Portal"
 SSO_MODULE = "SSO"
 WEBHOOKS_MODULE = "Webhooks"
 MFA_MODULE = "MFA"
-USERS_MODULE = "UserManagement"
+USER_MANAGEMENT_MODULE = "UserManagement"
 
 REQUIRED_SETTINGS_FOR_MODULE = {
     AUDIT_LOGS_MODULE: [
@@ -43,7 +43,7 @@ REQUIRED_SETTINGS_FOR_MODULE = {
     ],
     WEBHOOKS_MODULE: ["api_key"],
     MFA_MODULE: ["api_key"],
-    USERS_MODULE: ["client_id", "api_key"],
+    USER_MANAGEMENT_MODULE: ["client_id", "api_key"],
 }
 
 


### PR DESCRIPTION
## Description

Renames the `User` class to `UserManagement`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.