### PR TITLE
Fix `get_user`, `list_users`, and `delete_user` methods

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -23,7 +23,7 @@ class TestUserManagement(object):
             "list_metadata": {"before": None, "after": None},
             "metadata": {
                 "params": {
-                    "organization": None,
+                    "organization_id": None,
                     "email": None,
                     "limit": None,
                     "before": None,
@@ -45,7 +45,7 @@ class TestUserManagement(object):
             "metadata": {
                 "params": {
                     "type": None,
-                    "organization": None,
+                    "organization_id": None,
                     "email": None,
                     "limit": 4,
                     "before": None,
@@ -67,7 +67,7 @@ class TestUserManagement(object):
             "metadata": {
                 "params": {
                     "type": None,
-                    "organization": None,
+                    "organization_id": None,
                     "email": None,
                     "limit": None,
                     "before": None,
@@ -143,7 +143,7 @@ class TestUserManagement(object):
 
         user = self.user_management.get_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
 
-        assert url[0].endswith("users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
+        assert url[0].endswith("user_management/users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
         assert user["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
 
     def test_list_users_auto_pagination(
@@ -179,19 +179,19 @@ class TestUserManagement(object):
 
         users = self.user_management.list_users(
             email="marcelina@foo-corp.com",
-            organization="foo-corp.com",
+            organization_id="org_12345",
         )
 
         dict_users = users.to_dict()
         assert dict_users["metadata"]["params"]["email"] == "marcelina@foo-corp.com"
-        assert dict_users["metadata"]["params"]["organization"] == "foo-corp.com"
+        assert dict_users["metadata"]["params"]["organization_id"] == "org_12345"
 
     def test_delete_user(self, capture_and_mock_request):
         url, request_kwargs = capture_and_mock_request("delete", None, 200)
 
         user = self.user_management.delete_user("user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
 
-        assert url[0].endswith("users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
+        assert url[0].endswith("user_management/users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")
         assert user is None
 
     def test_update_user(self, mock_user, capture_and_mock_request):

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -15,8 +15,8 @@ from workos.utils.request import (
 )
 from workos.utils.validation import validate_settings, USER_MANAGEMENT_MODULE
 
-USER_PATH = "users"
-USER_DETAIL_PATH = "users/{0}"
+USER_PATH = "user_management/users"
+USER_DETAIL_PATH = "user_management/users/{0}"
 USER_ORGANIZATION_PATH = "users/{0}/organization/{1}"
 USER_PASSWORD_PATH = "users/{0}/password"
 USER_AUTHENTICATE_PATH = "users/authenticate"
@@ -90,7 +90,7 @@ class UserManagement(WorkOSListResource):
     def list_users(
         self,
         email=None,
-        organization=None,
+        organization_id=None,
         limit=None,
         before=None,
         after=None,
@@ -100,7 +100,7 @@ class UserManagement(WorkOSListResource):
 
         Kwargs:
             email (str): Filter Users by their email. (Optional)
-            organization (list): Filter Users by the organization they are members of. (Optional)
+            organization_id (str): Filter Users by the organization they are members of. (Optional)
             limit (int): Maximum number of records to return. (Optional)
             before (str): Pagination cursor to receive records before a provided User ID. (Optional)
             after (str): Pagination cursor to receive records after a provided User ID. (Optional)
@@ -118,7 +118,7 @@ class UserManagement(WorkOSListResource):
 
         params = {
             "email": email,
-            "organization": organization,
+            "organization_id": organization_id,
             "limit": limit,
             "before": before,
             "after": after,


### PR DESCRIPTION
## Description

Updates the `get_user`, `list_users`, and `delete_user` methods to match the current User Management API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.