### PR TITLE
Finalize `send_magic_auth_code` method

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -387,6 +387,6 @@ class TestUserManagement(object):
 
         response = self.user_management.send_magic_auth_code(email=email)
 
-        assert url[0].endswith("users/magic_auth/send")
-        assert request["json"]["email_address"] == email
+        assert url[0].endswith("user_management/magic_auth/send")
+        assert request["json"]["email"] == email
         assert response["id"] == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -24,7 +24,7 @@ USER_PASSWORD_RESET_CHALLENGE_PATH = "users/password_reset_challenge"
 USER_PASSWORD_RESET_PATH = "users/password_reset"
 USER_SEND_VERIFICATION_EMAIL_PATH = "users/{0}/send_verification_email"
 USER_VERIFY_EMAIL_CODE_PATH = "users/verify_email_code"
-USER_SEND_MAGIC_AUTH_PATH = "users/magic_auth/send"
+USER_SEND_MAGIC_AUTH_PATH = "user_management/magic_auth/send"
 
 RESPONSE_LIMIT = 10
 
@@ -522,13 +522,13 @@ class UserManagement(WorkOSListResource):
             email (str): The email address the one-time code will be sent to.
 
         Returns:
-            dict: MagicAuthChallenge response from WorkOS.
+            dict: User response from WorkOS.
         """
 
         headers = {}
 
         payload = {
-            "email_address": email,
+            "email": email,
         }
 
         response = self.request_helper.request(


### PR DESCRIPTION
## Description

Finalizes the `send_magic_auth_code` method

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.