### PR TITLE
Add invitations API methods

### DIFF
--- a/tests/utils/fixtures/mock_invitation.py
+++ b/tests/utils/fixtures/mock_invitation.py
@@ -1,0 +1,29 @@
+import datetime
+from workos.resources.base import WorkOSBaseResource
+
+
+class MockInvitation(WorkOSBaseResource):
+    def __init__(self, id):
+        self.id = id
+        self.email = "marcelina@foo-corp.com"
+        self.state = "pending"
+        self.accepted_at = None
+        self.revoked_at = None
+        self.expires_at = datetime.datetime.now()
+        self.token = "ABCDE12345"
+        self.organization_id = "org_12345"
+        self.created_at = datetime.datetime.now()
+        self.updated_at = datetime.datetime.now()
+
+    OBJECT_FIELDS = [
+        "id",
+        "email",
+        "state",
+        "accepted_at",
+        "revoked_at",
+        "expires_at",
+        "token",
+        "organization_id",
+        "created_at",
+        "updated_at",
+    ]

--- a/workos/resources/user_management.py
+++ b/workos/resources/user_management.py
@@ -26,6 +26,27 @@ class WorkOSAuthenticationResponse(WorkOSBaseResource):
         return authentication_response_dict
 
 
+class WorkOSInvitation(WorkOSBaseResource):
+    """Representation of an Invitation as returned by WorkOS through User Management features.
+
+    Attributes:
+        OBJECT_FIELDS (list): List of fields a WorkOSInvitation comprises.
+    """
+
+    OBJECT_FIELDS = [
+        "id",
+        "email",
+        "state",
+        "accepted_at",
+        "revoked_at",
+        "expires_at",
+        "token",
+        "organization_id",
+        "created_at",
+        "updated_at",
+    ]
+
+
 class WorkOSOrganizationMembership(WorkOSBaseResource):
     """Representation of an Organization Membership as returned by WorkOS through User Management features.
 


### PR DESCRIPTION
## Description

Adds methods and resources for the invitations API (part of user management)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.