### PR TITLE
Add UM `get_authorization_url` method

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -235,7 +235,7 @@ class TestSSO(object):
                 state=self.state,
             )
 
-    def test_authorization_url_throws_value_error_wihout_redirect_uri(
+    def test_authorization_url_throws_value_error_without_redirect_uri(
         self, setup_with_client_id
     ):
         with pytest.raises(

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -4,6 +4,7 @@ import pytest
 import workos
 from workos.sso import SSO
 from workos.utils.connection_types import ConnectionType
+from workos.utils.provider_types import ProviderType
 from workos.utils.request import RESPONSE_TYPE_CODE
 from tests.utils.fixtures.mock_connection import MockConnection
 
@@ -12,7 +13,7 @@ class TestSSO(object):
     @pytest.fixture
     def setup_with_client_id(self, set_api_key_and_client_id):
         self.sso = SSO()
-        self.provider = ConnectionType.GoogleOAuth
+        self.provider = ProviderType.GoogleOAuth
         self.customer_domain = "workos.com"
         self.login_hint = "foo@workos.com"
         self.redirect_uri = "https://localhost/auth/callback"
@@ -204,19 +205,11 @@ class TestSSO(object):
                 redirect_uri=self.redirect_uri, state=self.state
             )
 
-    def test_authorization_url_throws_value_error_with_incorrect_string_provider_value(
-        self, setup_with_client_id
-    ):
-        with pytest.raises(ValueError, match=r"Invalid provider. Must be one of *"):
-            self.sso.get_authorization_url(
-                provider="foo", redirect_uri=self.redirect_uri, state=self.state
-            )
-
     @pytest.mark.parametrize(
         "invalid_provider",
         [
             123,
-            ConnectionType,
+            ProviderType,
             True,
             False,
             {"provider": "GoogleOAuth"},
@@ -226,9 +219,7 @@ class TestSSO(object):
     def test_authorization_url_throws_value_error_with_incorrect_provider_type(
         self, setup_with_client_id, invalid_provider
     ):
-        with pytest.raises(
-            ValueError, match="'provider' must be of type ConnectionType"
-        ):
+        with pytest.raises(ValueError, match="'provider' must be of type ProviderType"):
             self.sso.get_authorization_url(
                 provider=invalid_provider,
                 redirect_uri=self.redirect_uri,
@@ -348,7 +339,7 @@ class TestSSO(object):
         self, setup_with_client_id
     ):
         authorization_url = self.sso.get_authorization_url(
-            provider=self.provider.value,
+            provider=self.provider,
             organization=self.organization,
             redirect_uri=self.redirect_uri,
             state=self.state,

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -4,7 +4,7 @@ import pytest
 import workos
 from workos.sso import SSO
 from workos.utils.connection_types import ConnectionType
-from workos.utils.provider_types import ProviderType
+from workos.utils.sso_provider_types import SsoProviderType
 from workos.utils.request import RESPONSE_TYPE_CODE
 from tests.utils.fixtures.mock_connection import MockConnection
 
@@ -13,7 +13,7 @@ class TestSSO(object):
     @pytest.fixture
     def setup_with_client_id(self, set_api_key_and_client_id):
         self.sso = SSO()
-        self.provider = ProviderType.GoogleOAuth
+        self.provider = SsoProviderType.GoogleOAuth
         self.customer_domain = "workos.com"
         self.login_hint = "foo@workos.com"
         self.redirect_uri = "https://localhost/auth/callback"
@@ -209,7 +209,7 @@ class TestSSO(object):
         "invalid_provider",
         [
             123,
-            ProviderType,
+            SsoProviderType,
             True,
             False,
             {"provider": "GoogleOAuth"},
@@ -219,7 +219,9 @@ class TestSSO(object):
     def test_authorization_url_throws_value_error_with_incorrect_provider_type(
         self, setup_with_client_id, invalid_provider
     ):
-        with pytest.raises(ValueError, match="'provider' must be of type ProviderType"):
+        with pytest.raises(
+            ValueError, match="'provider' must be of type SsoProviderType"
+        ):
             self.sso.get_authorization_url(
                 provider=invalid_provider,
                 redirect_uri=self.redirect_uri,

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -1,4 +1,7 @@
+import json
+from six.moves.urllib.parse import parse_qsl, urlparse
 import pytest
+import workos
 
 from tests.utils.fixtures.mock_auth_factor_totp import MockAuthFactorTotp
 from tests.utils.fixtures.mock_invitation import MockInvitation
@@ -6,6 +9,7 @@ from tests.utils.fixtures.mock_organization_membership import MockOrganizationMe
 from tests.utils.fixtures.mock_session import MockSession
 from tests.utils.fixtures.mock_user import MockUser
 from workos.user_management import UserManagement
+from workos.utils.request import RESPONSE_TYPE_CODE
 
 
 class TestUserManagement(object):
@@ -346,6 +350,126 @@ class TestUserManagement(object):
 
         assert url[0].endswith("user_management/organization_memberships/om_ABCDE")
         assert user is None
+
+    def test_authorization_url_throws_value_error_with_missing_connection_organization_and_provider(
+        self,
+    ):
+        redirect_uri = "https://localhost/auth/callback"
+        with pytest.raises(ValueError, match=r"Incomplete arguments.*"):
+            self.user_management.get_authorization_url(redirect_uri=redirect_uri)
+
+    def test_authorization_url_has_expected_query_params_with_connection_id(self):
+        connection_id = "connection_123"
+        redirect_uri = "https://localhost/auth/callback"
+        authorization_url = self.user_management.get_authorization_url(
+            connection_id=connection_id,
+            redirect_uri=redirect_uri,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "connection_id": connection_id,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_organization_id(self):
+        organization_id = "organization_123"
+        redirect_uri = "https://localhost/auth/callback"
+        authorization_url = self.user_management.get_authorization_url(
+            organization_id=organization_id,
+            redirect_uri=redirect_uri,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "organization_id": organization_id,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_provider(self):
+        provider = "GoogleOAuth"
+        redirect_uri = "https://localhost/auth/callback"
+        authorization_url = self.user_management.get_authorization_url(
+            provider=provider, redirect_uri=redirect_uri
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "provider": provider,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_domain_hint(self):
+        connection_id = "connection_123"
+        redirect_uri = "https://localhost/auth/callback"
+        domain_hint = "workos.com"
+
+        authorization_url = self.user_management.get_authorization_url(
+            connection_id=connection_id,
+            domain_hint=domain_hint,
+            redirect_uri=redirect_uri,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "domain_hint": domain_hint,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "connection_id": connection_id,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_login_hint(self):
+        connection_id = "connection_123"
+        redirect_uri = "https://localhost/auth/callback"
+        login_hint = "foo@workos.com"
+
+        authorization_url = self.user_management.get_authorization_url(
+            connection_id=connection_id,
+            login_hint=login_hint,
+            redirect_uri=redirect_uri,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "login_hint": login_hint,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "connection_id": connection_id,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_state(self):
+        connection_id = "connection_123"
+        redirect_uri = "https://localhost/auth/callback"
+        state = json.dumps({"things": "with_stuff"})
+
+        authorization_url = self.user_management.get_authorization_url(
+            connection_id=connection_id,
+            state=state,
+            redirect_uri=redirect_uri,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "state": state,
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "connection_id": connection_id,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
 
     def test_authenticate_with_password(
         self, capture_and_mock_request, mock_auth_response

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -9,7 +9,7 @@ from tests.utils.fixtures.mock_organization_membership import MockOrganizationMe
 from tests.utils.fixtures.mock_session import MockSession
 from tests.utils.fixtures.mock_user import MockUser
 from workos.user_management import UserManagement
-from workos.utils.provider_types import ProviderType
+from workos.utils.um_provider_types import UserManagementProviderType
 from workos.utils.request import RESPONSE_TYPE_CODE
 
 
@@ -374,7 +374,7 @@ class TestUserManagement(object):
         "invalid_provider",
         [
             123,
-            ProviderType,
+            UserManagementProviderType,
             True,
             False,
             {"provider": "GoogleOAuth"},
@@ -384,7 +384,9 @@ class TestUserManagement(object):
     def test_authorization_url_throws_value_error_with_incorrect_provider_type(
         self, invalid_provider
     ):
-        with pytest.raises(ValueError, match="'provider' must be of type ProviderType"):
+        with pytest.raises(
+            ValueError, match="'provider' must be of type UserManagementProviderType"
+        ):
             redirect_uri = "https://localhost/auth/callback"
             self.user_management.get_authorization_url(
                 provider=invalid_provider,
@@ -426,7 +428,7 @@ class TestUserManagement(object):
         }
 
     def test_authorization_url_has_expected_query_params_with_provider(self):
-        provider = ProviderType.GoogleOAuth
+        provider = UserManagementProviderType.GoogleOAuth
         redirect_uri = "https://localhost/auth/callback"
         authorization_url = self.user_management.get_authorization_url(
             provider=provider, redirect_uri=redirect_uri

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -351,6 +351,17 @@ class TestUserManagement(object):
         assert url[0].endswith("user_management/organization_memberships/om_ABCDE")
         assert user is None
 
+    def test_authorization_url_throws_value_error_without_redirect_uri(self):
+        connection_id = "connection_123"
+        login_hint = "foo@workos.com"
+        state = json.dumps({"things": "with_stuff"})
+        with pytest.raises(TypeError):
+            self.user_management.get_authorization_url(
+                connection_id=connection_id,
+                login_hint=login_hint,
+                state=state,
+            )
+
     def test_authorization_url_throws_value_error_with_missing_connection_organization_and_provider(
         self,
     ):

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -8,7 +8,7 @@ from workos.resources.sso import (
     WorkOSConnection,
 )
 from workos.utils.connection_types import ConnectionType
-from workos.utils.provider_types import ProviderType
+from workos.utils.sso_provider_types import SsoProviderType
 from workos.utils.request import (
     RequestHelper,
     RESPONSE_TYPE_CODE,
@@ -62,7 +62,7 @@ class SSO(WorkOSListResource):
             redirect_uri (str) - A valid redirect URI, as specified on WorkOS
             state (str) - An encoded string passed to WorkOS that'd be preserved through the authentication workflow, passed
             back as a query parameter
-            provider (ProviderType) - Authentication service provider descriptor
+            provider (SsoProviderType) - Authentication service provider descriptor
             connection (string) - Unique identifier for a WorkOS Connection
             organization (string) - Unique identifier for a WorkOS Organization
 
@@ -85,8 +85,8 @@ class SSO(WorkOSListResource):
                 "Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'"
             )
         if provider is not None:
-            if not isinstance(provider, ProviderType):
-                raise ValueError("'provider' must be of type ProviderType")
+            if not isinstance(provider, SsoProviderType):
+                raise ValueError("'provider' must be of type SsoProviderType")
 
             params["provider"] = provider.value
         if domain is not None:

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -8,6 +8,7 @@ from workos.resources.sso import (
     WorkOSConnection,
 )
 from workos.utils.connection_types import ConnectionType
+from workos.utils.provider_types import ProviderType
 from workos.utils.request import (
     RequestHelper,
     RESPONSE_TYPE_CODE,
@@ -61,7 +62,7 @@ class SSO(WorkOSListResource):
             redirect_uri (str) - A valid redirect URI, as specified on WorkOS
             state (str) - An encoded string passed to WorkOS that'd be preserved through the authentication workflow, passed
             back as a query parameter
-            provider (ConnectionType) - Authentication service provider descriptor
+            provider (ProviderType) - Authentication service provider descriptor
             connection (string) - Unique identifier for a WorkOS Connection
             organization (string) - Unique identifier for a WorkOS Organization
 
@@ -84,19 +85,8 @@ class SSO(WorkOSListResource):
                 "Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'"
             )
         if provider is not None:
-            if isinstance(provider, str):
-                # Temporary backport to support clients still using `connection_type` as a string
-                providers = ConnectionType.providers()
-                if provider not in providers:
-                    raise ValueError(
-                        "Invalid provider. Must be one of {}, got '{}'".format(
-                            list(providers), provider
-                        )
-                    )
-                provider = ConnectionType[provider]
-
-            elif not isinstance(provider, ConnectionType):
-                raise ValueError("'provider' must be of type ConnectionType")
+            if not isinstance(provider, ProviderType):
+                raise ValueError("'provider' must be of type ProviderType")
 
             params["provider"] = provider.value
         if domain is not None:

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -10,6 +10,7 @@ from workos.resources.user_management import (
     WorkOSUser,
 )
 from workos.utils.pagination_order import Order
+from workos.utils.provider_types import ProviderType
 from workos.utils.request import (
     RequestHelper,
     RESPONSE_TYPE_CODE,
@@ -340,7 +341,7 @@ class UserManagement(WorkOSListResource):
                 The value of this parameter should be a WorkOS Connection ID. (Optional)
             organization_id (str) - The organization_id connection selector is used to initiate SSO for an Organization.
                 The value of this parameter should be a WorkOS Organization ID. (Optional)
-            provider (str) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
+            provider (ProviderType) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
                 Currently, the supported values for provider are 'authkit', 'GoogleOAuth' and 'MicrosoftOAuth'. (Optional)
             domain_hint (str) - Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
                 or with a GoogleSAML connection type. (Optional)
@@ -369,7 +370,10 @@ class UserManagement(WorkOSListResource):
         if organization_id is not None:
             params["organization_id"] = organization_id
         if provider is not None:
-            params["provider"] = provider
+            if not isinstance(provider, ProviderType):
+                raise ValueError("'provider' must be of type ProviderType")
+
+            params["provider"] = provider.value
         if domain_hint is not None:
             params["domain_hint"] = domain_hint
         if login_hint is not None:

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -10,7 +10,7 @@ from workos.resources.user_management import (
     WorkOSUser,
 )
 from workos.utils.pagination_order import Order
-from workos.utils.provider_types import ProviderType
+from workos.utils.um_provider_types import UserManagementProviderType
 from workos.utils.request import (
     RequestHelper,
     RESPONSE_TYPE_CODE,
@@ -341,7 +341,7 @@ class UserManagement(WorkOSListResource):
                 The value of this parameter should be a WorkOS Connection ID. (Optional)
             organization_id (str) - The organization_id connection selector is used to initiate SSO for an Organization.
                 The value of this parameter should be a WorkOS Organization ID. (Optional)
-            provider (ProviderType) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
+            provider (UserManagementProviderType) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
                 Currently, the supported values for provider are 'authkit', 'GoogleOAuth' and 'MicrosoftOAuth'. (Optional)
             domain_hint (str) - Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
                 or with a GoogleSAML connection type. (Optional)
@@ -370,8 +370,10 @@ class UserManagement(WorkOSListResource):
         if organization_id is not None:
             params["organization_id"] = organization_id
         if provider is not None:
-            if not isinstance(provider, ProviderType):
-                raise ValueError("'provider' must be of type ProviderType")
+            if not isinstance(provider, UserManagementProviderType):
+                raise ValueError(
+                    "'provider' must be of type UserManagementProviderType"
+                )
 
             params["provider"] = provider.value
         if domain_hint is not None:

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -1,3 +1,4 @@
+from requests import Request
 import workos
 from workos.resources.list import WorkOSListResource
 from workos.resources.mfa import WorkOSAuthenticationFactorTotp, WorkOSChallenge
@@ -11,6 +12,7 @@ from workos.resources.user_management import (
 from workos.utils.pagination_order import Order
 from workos.utils.request import (
     RequestHelper,
+    RESPONSE_TYPE_CODE,
     REQUEST_METHOD_POST,
     REQUEST_METHOD_GET,
     REQUEST_METHOD_DELETE,
@@ -22,6 +24,7 @@ USER_PATH = "user_management/users"
 USER_DETAIL_PATH = "user_management/users/{0}"
 ORGANIZATION_MEMBERSHIP_PATH = "user_management/organization_memberships"
 ORGANIZATION_MEMBERSHIP_DETAIL_PATH = "user_management/organization_memberships/{0}"
+USER_AUTHORIZATION_PATH = "user_management/authorize"
 USER_AUTHENTICATE_PATH = "user_management/authenticate"
 USER_SEND_PASSWORD_RESET_PATH = "user_management/password_reset/send"
 USER_RESET_PASSWORD_PATH = "user_management/password_reset/confirm"
@@ -315,6 +318,72 @@ class UserManagement(WorkOSListResource):
             method=REQUEST_METHOD_DELETE,
             token=workos.api_key,
         )
+
+    def get_authorization_url(
+        self,
+        redirect_uri,
+        connection_id=None,
+        organization_id=None,
+        provider=None,
+        domain_hint=None,
+        login_hint=None,
+        state=None,
+    ):
+        """Generate an OAuth 2.0 authorization URL.
+
+        The URL generated will redirect a User to the Identity Provider configured through
+        WorkOS.
+
+        Kwargs:
+            redirect_uri (str) - A Redirect URI to return an authorized user to.
+            connection_id (str) - The connection_id connection selector is used to initiate SSO for a Connection.
+                The value of this parameter should be a WorkOS Connection ID. (Optional)
+            organization_id (str) - The organization_id connection selector is used to initiate SSO for an Organization.
+                The value of this parameter should be a WorkOS Organization ID. (Optional)
+            provider (str) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
+                Currently, the supported values for provider are 'authkit', 'GoogleOAuth' and 'MicrosoftOAuth'. (Optional)
+            domain_hint (str) - Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
+                or with a GoogleSAML connection type. (Optional)
+            login_hint (str) - Can be used to pre-fill the username/email address field of the IdP sign-in page for the user,
+                if you know their username ahead of time. Currently, this parameter is supported for OAuth, OpenID Connect,
+                OktaSAML, and AzureSAML connection types. (Optional)
+            state (str) - An encoded string passed to WorkOS that'd be preserved through the authentication workflow, passed
+                back as a query parameter. (Optional)
+
+        Returns:
+            str: URL to redirect a User to to begin the OAuth workflow with WorkOS
+        """
+        params = {
+            "client_id": workos.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+        }
+
+        if connection_id is None and organization_id is None and provider is None:
+            raise ValueError(
+                "Incomplete arguments. Need to specify either a 'connection_id', 'organization_id', or 'provider_id'"
+            )
+
+        if connection_id is not None:
+            params["connection_id"] = connection_id
+        if organization_id is not None:
+            params["organization_id"] = organization_id
+        if provider is not None:
+            params["provider"] = provider
+        if domain_hint is not None:
+            params["domain_hint"] = domain_hint
+        if login_hint is not None:
+            params["login_hint"] = login_hint
+        if state is not None:
+            params["state"] = state
+
+        prepared_request = Request(
+            "GET",
+            self.request_helper.generate_api_url(USER_AUTHORIZATION_PATH),
+            params=params,
+        ).prepare()
+
+        return prepared_request.url
 
     def authenticate_with_password(
         self,

--- a/workos/utils/provider_types.py
+++ b/workos/utils/provider_types.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class ProviderType(Enum):
+    AuthKit = "authkit"
+    GoogleOAuth = "GoogleOAuth"
+    MicrosoftOAuth = "MicrosoftOAuth"

--- a/workos/utils/sso_provider_types.py
+++ b/workos/utils/sso_provider_types.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
 
-class ProviderType(Enum):
-    AuthKit = "authkit"
+class SsoProviderType(Enum):
     GoogleOAuth = "GoogleOAuth"
     MicrosoftOAuth = "MicrosoftOAuth"

--- a/workos/utils/um_provider_types.py
+++ b/workos/utils/um_provider_types.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class UserManagementProviderType(Enum):
+    AuthKit = "authkit"
+    GoogleOAuth = "GoogleOAuth"
+    MicrosoftOAuth = "MicrosoftOAuth"


### PR DESCRIPTION
## Description

Adds the UM specific `get_authorization_url` method.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.