### PR TITLE
Remove domain param from directories query

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -692,6 +692,7 @@ class TestUserManagement(object):
         assert request_kwargs["json"] == {
             **params,
             **base_authentication_params,
+            "organization_id": None,
             "grant_type": "refresh_token",
         }
 

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -72,7 +72,6 @@ class DirectorySyncModule(Protocol):
 
     def list_directories(
         self,
-        domain: Optional[str] = None,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -250,7 +249,6 @@ class DirectorySync(DirectorySyncModule):
 
     def list_directories(
         self,
-        domain: Optional[str] = None,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -261,8 +259,7 @@ class DirectorySync(DirectorySyncModule):
         """Gets details for existing Directories.
 
         Args:
-            domain (str): Domain of a Directory. (Optional)
-            organization: ID of an Organization (Optional)
+            organization_id: ID of an Organization (Optional)
             search (str): Searchable text for a Directory. (Optional)
             limit (int): Maximum number of records to return. (Optional)
             before (str): Pagination cursor to receive records before a provided Directory ID. (Optional)
@@ -278,7 +275,6 @@ class DirectorySync(DirectorySyncModule):
             "before": before,
             "after": after,
             "order": order,
-            "domain": domain,
             "organization_id": organization_id,
             "search": search,
         }
@@ -478,7 +474,6 @@ class AsyncDirectorySync(DirectorySyncModule):
 
     async def list_directories(
         self,
-        domain: Optional[str] = None,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -502,7 +497,6 @@ class AsyncDirectorySync(DirectorySyncModule):
         """
 
         list_params: DirectoryListFilters = {
-            "domain": domain,
             "organization_id": organization_id,
             "search": search,
             "limit": limit,

--- a/workos/resources/directory_sync.py
+++ b/workos/resources/directory_sync.py
@@ -28,10 +28,7 @@ DirectoryType = Literal[
 
 
 class Directory(WorkOSModel):
-    """Representation of a Directory Response as returned by WorkOS through the Directory Sync feature.
-    Attributes:
-        OBJECT_FIELDS (list): List of fields a Directory is comprised of.
-    """
+    """Representation of a Directory Response as returned by WorkOS through the Directory Sync feature."""
 
     id: str
     object: Literal["directory"]
@@ -46,11 +43,7 @@ class Directory(WorkOSModel):
 
 
 class DirectoryGroup(WorkOSModel):
-    """Representation of a Directory Group as returned by WorkOS through the Directory Sync feature.
-
-    Attributes:
-        OBJECT_FIELDS (list): List of fields a DirectoryGroup is comprised of.
-    """
+    """Representation of a Directory Group as returned by WorkOS through the Directory Sync feature."""
 
     id: str
     object: Literal["directory_group"]
@@ -64,10 +57,6 @@ class DirectoryGroup(WorkOSModel):
 
 
 class DirectoryUserWithGroups(DirectoryUser):
-    """Representation of a Directory User as returned by WorkOS through the Directory Sync feature.
-
-    Attributes:
-        OBJECT_FIELDS (list): List of fields a DirectoryUser is comprised of.
-    """
+    """Representation of a Directory User as returned by WorkOS through the Directory Sync feature."""
 
     groups: List[DirectoryGroup]

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -286,6 +286,7 @@ class UserManagementModule(Protocol):
     def authenticate_with_refresh_token(
         self,
         refresh_token: str,
+        organization_id: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
     ) -> RefreshTokenAuthenticationResponse: ...


### PR DESCRIPTION
## Description
We no longer support querying directories by domain.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.