### PR TITLE
Add status to organization membership

### DIFF
--- a/tests/utils/fixtures/mock_organization_membership.py
+++ b/tests/utils/fixtures/mock_organization_membership.py
@@ -7,6 +7,7 @@ class MockOrganizationMembership(WorkOSBaseResource):
         self.id = id
         self.user_id = "user_12345"
         self.organization_id = "org_67890"
+        self.status = "active"
         self.created_at = datetime.datetime.now()
         self.updated_at = datetime.datetime.now()
 
@@ -14,6 +15,7 @@ class MockOrganizationMembership(WorkOSBaseResource):
         "id",
         "user_id",
         "organization_id",
+        "status",
         "created_at",
         "updated_at",
     ]

--- a/workos/resources/user_management.py
+++ b/workos/resources/user_management.py
@@ -66,6 +66,7 @@ class WorkOSOrganizationMembership(WorkOSBaseResource):
         "id",
         "user_id",
         "organization_id",
+        "status",
         "created_at",
         "updated_at",
     ]


### PR DESCRIPTION
## Description

Adds `status` attribute to organization membership.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/25404