### PR TITLE
chore: default list methods to descending order

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,9 @@ name: Python
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+  containers:
+    - name: main
+      image: "registry.semaphoreci.com/python:3.7"
 blocks:
   - task:
       secrets:
@@ -15,7 +17,6 @@ blocks:
           - python -m pip install --upgrade pip
           - pip install -e .[dev]
       jobs:
-        # Coverage would be the same regardless of Python version
         - name: python3 + codecov
           commands:
             - sem-version python 3.7

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,19 +11,10 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version python 2.7
-          - python -m pip install --upgrade pip
-          - pip install -e .[dev]
           - sem-version python 3.7
           - python -m pip install --upgrade pip
           - pip install -e .[dev]
       jobs:
-        - name: python
-          commands:
-            - sem-version python 2.7
-            - flake8 . --count --select=E9,F7,F82 --show-source --statistics
-            - flake8 . --count --exit-zero --max-complexity=10 --statistics
-            - pytest
         # Coverage would be the same regardless of Python version
         - name: python3 + codecov
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,13 +13,11 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version python 3.7
           - python -m pip install --upgrade pip
           - pip install -e .[dev]
       jobs:
         - name: python3 + codecov
           commands:
-            - sem-version python 3.7
             - flake8 . --count --select=E9,F7,F82 --show-source --statistics
             - flake8 . --count --exit-zero --max-complexity=10 --statistics
             - pytest --cov-report xml --cov=workos

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Python
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - task:
       secrets:

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 __author__ = "WorkOS"
 

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "2.2.0"
+__version__ = "3.0.0"
 
 __author__ = "WorkOS"
 

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -84,7 +84,9 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-
+        else: 
+            params["order"] = "desc"
+            
         response = self.request_helper.request(
             "directory_users",
             method=REQUEST_METHOD_GET,
@@ -153,6 +155,8 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_users",
@@ -219,6 +223,8 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
+            else: 
+                params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_groups",
@@ -281,6 +287,8 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
+            else: 
+                params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_groups",
@@ -406,6 +414,8 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directories",
@@ -474,6 +484,8 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directories",

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -84,9 +84,9 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
-            
+
         response = self.request_helper.request(
             "directory_users",
             method=REQUEST_METHOD_GET,
@@ -155,7 +155,7 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -223,7 +223,7 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
-            else: 
+            else:
                 params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -287,7 +287,7 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
-            else: 
+            else:
                 params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -414,7 +414,7 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -484,7 +484,7 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -69,7 +69,7 @@ class DirectorySync(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if group is not None:
@@ -84,8 +84,6 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_users",
@@ -140,7 +138,7 @@ class DirectorySync(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if group is not None:
@@ -155,8 +153,6 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_users",
@@ -210,7 +206,12 @@ class DirectorySync(WorkOSListResource):
             limit = RESPONSE_LIMIT
             default_limit = True
 
-        params = {"limit": limit, "before": before, "after": after, "order": order}
+        params = {
+            "limit": limit,
+            "before": before,
+            "after": after,
+            "order": order or "desc",
+        }
         if user is not None:
             params["user"] = user
         if directory is not None:
@@ -223,8 +224,6 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
-            else:
-                params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_groups",
@@ -274,7 +273,12 @@ class DirectorySync(WorkOSListResource):
             limit = RESPONSE_LIMIT
             default_limit = True
 
-        params = {"limit": limit, "before": before, "after": after, "order": order}
+        params = {
+            "limit": limit,
+            "before": before,
+            "after": after,
+            "order": order or "desc",
+        }
         if user is not None:
             params["user"] = user
         if directory is not None:
@@ -287,8 +291,6 @@ class DirectorySync(WorkOSListResource):
                     params["order"] = order
                 else:
                     raise ValueError("Parameter order must be of enum type Order")
-            else:
-                params["order"] = "desc"
 
         response = self.request_helper.request(
             "directory_groups",
@@ -403,7 +405,7 @@ class DirectorySync(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -414,8 +416,6 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directories",
@@ -473,7 +473,7 @@ class DirectorySync(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -484,8 +484,6 @@ class DirectorySync(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "directories",

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -60,7 +60,7 @@ class Organizations(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -71,8 +71,6 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             ORGANIZATIONS_PATH,
@@ -124,7 +122,7 @@ class Organizations(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -135,8 +133,6 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             ORGANIZATIONS_PATH,

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -71,9 +71,9 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
-            
+
         response = self.request_helper.request(
             ORGANIZATIONS_PATH,
             method=REQUEST_METHOD_GET,
@@ -135,7 +135,7 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -71,7 +71,9 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-
+        else: 
+            params["order"] = "desc"
+            
         response = self.request_helper.request(
             ORGANIZATIONS_PATH,
             method=REQUEST_METHOD_GET,
@@ -133,6 +135,8 @@ class Organizations(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             ORGANIZATIONS_PATH,

--- a/workos/resources/list.py
+++ b/workos/resources/list.py
@@ -75,7 +75,7 @@ class WorkOSListResource(WorkOSBaseResource):
             params = {
                 "after": after,
                 "before": before,
-                "order": order,
+                "order": order or "desc",
             }
             params.update(resource_specific_params)
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -245,9 +245,9 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
-            
+
         response = self.request_helper.request(
             "connections",
             method=REQUEST_METHOD_GET,
@@ -330,7 +330,7 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -234,7 +234,7 @@ class SSO(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -245,8 +245,6 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "connections",
@@ -319,7 +317,7 @@ class SSO(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
-            "order": order,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -330,8 +328,6 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             "connections",

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -245,7 +245,9 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-
+        else: 
+            params["order"] = "desc"
+            
         response = self.request_helper.request(
             "connections",
             method=REQUEST_METHOD_GET,
@@ -328,6 +330,8 @@ class SSO(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             "connections",

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -116,6 +116,8 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             USER_PATH,
@@ -287,6 +289,8 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
+        else: 
+            params["order"] = "desc"
 
         response = self.request_helper.request(
             ORGANIZATION_MEMBERSHIP_PATH,
@@ -953,7 +957,9 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-
+        else: 
+            params["order"] = "desc"
+            
         response = self.request_helper.request(
             INVITATION_PATH,
             method=REQUEST_METHOD_GET,

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -853,16 +853,16 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge["authentication_factor"] = (
-            WorkOSAuthenticationFactorTotp.construct_from_response(
-                response["authentication_factor"]
-            ).to_dict()
-        )
-        factor_and_challenge["authentication_challenge"] = (
-            WorkOSChallenge.construct_from_response(
-                response["authentication_challenge"]
-            ).to_dict()
-        )
+        factor_and_challenge[
+            "authentication_factor"
+        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
+            response["authentication_factor"]
+        ).to_dict()
+        factor_and_challenge[
+            "authentication_challenge"
+        ] = WorkOSChallenge.construct_from_response(
+            response["authentication_challenge"]
+        ).to_dict()
 
         return factor_and_challenge
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -107,6 +107,7 @@ class UserManagement(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -116,8 +117,6 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             USER_PATH,
@@ -280,6 +279,7 @@ class UserManagement(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -289,8 +289,6 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             ORGANIZATION_MEMBERSHIP_PATH,
@@ -948,6 +946,7 @@ class UserManagement(WorkOSListResource):
             "limit": limit,
             "before": before,
             "after": after,
+            "order": order or "desc",
         }
 
         if order is not None:
@@ -957,8 +956,6 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else:
-            params["order"] = "desc"
 
         response = self.request_helper.request(
             INVITATION_PATH,

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -116,7 +116,7 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -289,7 +289,7 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
 
         response = self.request_helper.request(
@@ -853,16 +853,16 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge[
-            "authentication_factor"
-        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
-            response["authentication_factor"]
-        ).to_dict()
-        factor_and_challenge[
-            "authentication_challenge"
-        ] = WorkOSChallenge.construct_from_response(
-            response["authentication_challenge"]
-        ).to_dict()
+        factor_and_challenge["authentication_factor"] = (
+            WorkOSAuthenticationFactorTotp.construct_from_response(
+                response["authentication_factor"]
+            ).to_dict()
+        )
+        factor_and_challenge["authentication_challenge"] = (
+            WorkOSChallenge.construct_from_response(
+                response["authentication_challenge"]
+            ).to_dict()
+        )
 
         return factor_and_challenge
 
@@ -957,9 +957,9 @@ class UserManagement(WorkOSListResource):
                 params["order"] = order
             else:
                 raise ValueError("Parameter order must be of enum type Order")
-        else: 
+        else:
             params["order"] = "desc"
-            
+
         response = self.request_helper.request(
             INVITATION_PATH,
             method=REQUEST_METHOD_GET,


### PR DESCRIPTION
## Description
- Default list methods to descending order. 
- Remove tests on python v2 

## Documentation
Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.