### PR TITLE
Add role to OrganizationMembership class

### DIFF
--- a/tests/utils/fixtures/mock_organization_membership.py
+++ b/tests/utils/fixtures/mock_organization_membership.py
@@ -8,6 +8,7 @@ class MockOrganizationMembership(WorkOSBaseResource):
         self.user_id = "user_12345"
         self.organization_id = "org_67890"
         self.status = "active"
+        self.role = { "slug": "member" },
         self.created_at = datetime.datetime.now()
         self.updated_at = datetime.datetime.now()
 
@@ -16,6 +17,7 @@ class MockOrganizationMembership(WorkOSBaseResource):
         "user_id",
         "organization_id",
         "status",
+        "role",
         "created_at",
         "updated_at",
     ]

--- a/workos/resources/user_management.py
+++ b/workos/resources/user_management.py
@@ -69,6 +69,7 @@ class WorkOSOrganizationMembership(WorkOSBaseResource):
         "status",
         "created_at",
         "updated_at",
+        "role",
     ]
 
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -201,19 +201,21 @@ class UserManagement(WorkOSListResource):
             token=workos.api_key,
         )
 
-    def create_organization_membership(self, user_id, organization_id):
+    def create_organization_membership(self, user_id, organization_id, role_slug):
         """Create a new OrganizationMembership for the given Organization and User.
 
         Args:
             user_id: The Unique ID of the User.
             organization_id: The Unique ID of the Organization to which the user belongs to.
+            role_slug: The Unique Slug of the Role to which to grant to this membership. 
+                If no slug is passed in, the default role will be granted.(Optional)
 
         Returns:
             dict: Created OrganizationMembership response from WorkOS.
         """
         headers = {}
 
-        params = {"user_id": user_id, "organization_id": organization_id}
+        params = {"user_id": user_id, "organization_id": organization_id, "role_slug": role_slug}
 
         response = self.request_helper.request(
             ORGANIZATION_MEMBERSHIP_PATH,


### PR DESCRIPTION
## Description
New "role" parameter which is used in the User Management OrganizationMemberships API

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.