### PR TITLE
Bump version of python in `publish.yml` workflow

### DIFF
--- a/.semaphore/publish.yml
+++ b/.semaphore/publish.yml
@@ -15,7 +15,7 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version python 3.7
+          - sem-version python 3.10
           - python -m pip install --upgrade pip
           - pip install -e .[dev]
       jobs:


### PR DESCRIPTION
## Description

Saw the following error when attempting to publish a new version:

```
[20:04 21/03/2024]: Changing 'python' to version 3.700:00
Usage:00:00
  change-python-version <version>00:00
  Supported versions are: 3.12, 3.11, 3.1000:00
! [20:04 21/03/2024]: Failed to switch version.
```

I imagine this was related to the recent Semaphore image changes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.