### PR TITLE
Add `role_slug` to user management send invitation flow

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 __author__ = "WorkOS"
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -886,16 +886,16 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge[
-            "authentication_factor"
-        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
-            response["authentication_factor"]
-        ).to_dict()
-        factor_and_challenge[
-            "authentication_challenge"
-        ] = WorkOSChallenge.construct_from_response(
-            response["authentication_challenge"]
-        ).to_dict()
+        factor_and_challenge["authentication_factor"] = (
+            WorkOSAuthenticationFactorTotp.construct_from_response(
+                response["authentication_factor"]
+            ).to_dict()
+        )
+        factor_and_challenge["authentication_challenge"] = (
+            WorkOSChallenge.construct_from_response(
+                response["authentication_challenge"]
+            ).to_dict()
+        )
 
         return factor_and_challenge
 
@@ -1013,7 +1013,12 @@ class UserManagement(WorkOSListResource):
         return self.construct_from_response(response)
 
     def send_invitation(
-        self, email, organization_id=None, expires_in_days=None, inviter_user_id=None, role_slug=None,
+        self,
+        email,
+        organization_id=None,
+        expires_in_days=None,
+        inviter_user_id=None,
+        role_slug=None,
     ):
         """Sends an Invitation to a recipient.
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -886,16 +886,16 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge["authentication_factor"] = (
-            WorkOSAuthenticationFactorTotp.construct_from_response(
-                response["authentication_factor"]
-            ).to_dict()
-        )
-        factor_and_challenge["authentication_challenge"] = (
-            WorkOSChallenge.construct_from_response(
-                response["authentication_challenge"]
-            ).to_dict()
-        )
+        factor_and_challenge[
+            "authentication_factor"
+        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
+            response["authentication_factor"]
+        ).to_dict()
+        factor_and_challenge[
+            "authentication_challenge"
+        ] = WorkOSChallenge.construct_from_response(
+            response["authentication_challenge"]
+        ).to_dict()
 
         return factor_and_challenge
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -1013,7 +1013,7 @@ class UserManagement(WorkOSListResource):
         return self.construct_from_response(response)
 
     def send_invitation(
-        self, email, organization_id=None, expires_in_days=None, inviter_user_id=None
+        self, email, organization_id=None, expires_in_days=None, inviter_user_id=None, role_slug=None,
     ):
         """Sends an Invitation to a recipient.
 
@@ -1022,6 +1022,7 @@ class UserManagement(WorkOSListResource):
             organization_id: The ID of the Organization to which the recipient is being invited. (Optional)
             expires_in_days: The number of days the invitations will be valid for. Must be between 1 and 30, defaults to 7 if not specified. (Optional)
             inviter_user_id: The ID of the User sending the invitation. (Optional)
+            role_slug: The unique slug of the Role to give the Membership once the invite is accepted (Optional)
 
         Returns:
             dict: Sent Invitation response from WorkOS.
@@ -1033,6 +1034,7 @@ class UserManagement(WorkOSListResource):
             "organization_id": organization_id,
             "expires_in_days": expires_in_days,
             "inviter_user_id": inviter_user_id,
+            "role_slug": role_slug,
         }
 
         response = self.request_helper.request(


### PR DESCRIPTION
## Description
`role_slug` is an optional parameter when sending an invite

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.