### PR TITLE
Add 'password_hash' and 'password_hash_type' to User creation

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 __author__ = "WorkOS"
 

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.2.1"
+__version__ = "4.2.0"
 
 __author__ = "WorkOS"
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -147,7 +147,7 @@ class UserManagement(WorkOSListResource):
                 user[email] (str) - The email address of the user.
                 user[password] (str) - The password to set for the user. (Optional)
                 user[password_hash] (str) - The hashed password to set for the user. Mutually exclusive with password. (Optional)
-                user[password_hash_type] (str) - The algorithm originally used to hash the password, used when providing a password_hash. Only valid value is 'bcrypt'. (Optional)
+                user[password_hash_type] (str) - The algorithm originally used to hash the password, used when providing a password_hash. Valid values are 'bcrypt', `firebase-scrypt`, and `ssha`. (Optional)
                 user[first_name] (str) - The user's first name. (Optional)
                 user[last_name] (str) - The user's last name. (Optional)
                 user[email_verified] (bool) - Whether the user's email address was previously verified. (Optional)
@@ -178,7 +178,7 @@ class UserManagement(WorkOSListResource):
                 payload[email_verified] (bool) - Whether the user's email address was previously verified. (Optional)
                 payload[password] (str) - The password to set for the user. (Optional)
                 payload[password_hash] (str) - The hashed password to set for the user, used when migrating from another user store. Mutually exclusive with password. (Optional)
-                payload[password_hash_type] (str) - The algorithm originally used to hash the password, used when providing a password_hash. Only valid value is 'bcrypt'. (Optional)
+                payload[password_hash_type] (str) - The algorithm originally used to hash the password, used when providing a password_hash. Valid values are 'bcrypt', `firebase-scrypt`, and `ssha`. (Optional)
 
         Returns:
             dict: Updated User response from WorkOS.

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -146,6 +146,8 @@ class UserManagement(WorkOSListResource):
             user (dict) - An user object
                 user[email] (str) - The email address of the user.
                 user[password] (str) - The password to set for the user. (Optional)
+                user[password_hash] (str) - The hashed password to set for the user. Mutually exclusive with password. (Optional)
+                user[password_hash_type] (str) - The algorithm originally used to hash the password, used when providing a password_hash. Only valid value is 'bcrypt'. (Optional)
                 user[first_name] (str) - The user's first name. (Optional)
                 user[last_name] (str) - The user's last name. (Optional)
                 user[email_verified] (bool) - Whether the user's email address was previously verified. (Optional)


### PR DESCRIPTION
## Description
This PR ensures that the User create process allows for the `password_hash` and `password_hash_type` fields, in addition to the existing `password` field, similar to the Update process.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26060
