### PR TITLE
Make events parameter required for list_events

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -31,15 +31,7 @@ class TestEvents(object):
     def test_list_events(self, mock_events, mock_request_method):
         mock_request_method("get", mock_events, 200)
 
-        events = self.events.list_events()
+        events = self.events.list_events(events=["dsync.user.created"])
 
         assert events == mock_events
-
-    def test_list_events_returns_metadata(self, mock_events, mock_request_method):
-        mock_request_method("get", mock_events, 200)
-
-        events = self.events.list_events(
-            events=["dsync.user.created"],
-        )
-
         assert events["metadata"]["params"]["events"] == ["dsync.user.created"]

--- a/workos/events.py
+++ b/workos/events.py
@@ -26,7 +26,7 @@ class Events(WorkOSListResource):
 
     def list_events(
         self,
-        events=None,
+        events,
         limit=None,
         after=None,
         range_start=None,
@@ -34,7 +34,7 @@ class Events(WorkOSListResource):
     ):
         """Gets a list of Events .
         Kwargs:
-            events (list): Filter to only return events of particular types. (Optional)
+            events (list): Filter to only return events of particular types.
             limit (int): Maximum number of records to return. (Optional)
             after (str): Pagination cursor to receive records after a provided Event ID. (Optional)
             range_start (str): Date range start for stream of events. (Optional)


### PR DESCRIPTION
## Description
Make events parameter required for listEvents.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/26139