### PR TITLE
Explicit coverage over creation of parameterized URLs

### DIFF
--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -151,6 +151,8 @@ class TestRequestHelper(object):
         assert RequestHelper().request("ok_place") == {"foo": "bar"}
 
     def test_build_url(self):
-        assert RequestHelper().build_parameterized_url('a/b/c') == 'a/b/c'
-        assert RequestHelper().build_parameterized_url('a/{b}/c', b='b') == 'a/b/c'
-        assert RequestHelper().build_parameterized_url('a/{b}/c', b='test') == 'a/test/c'
+        assert RequestHelper().build_parameterized_url("a/b/c") == "a/b/c"
+        assert RequestHelper().build_parameterized_url("a/{b}/c", b="b") == "a/b/c"
+        assert (
+            RequestHelper().build_parameterized_url("a/{b}/c", b="test") == "a/test/c"
+        )

--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -149,3 +149,8 @@ class TestRequestHelper(object):
         )
 
         assert RequestHelper().request("ok_place") == {"foo": "bar"}
+
+    def test_build_url(self):
+        assert RequestHelper().build_parameterized_url('a/b/c') == 'a/b/c'
+        assert RequestHelper().build_parameterized_url('a/{b}/c', b='b') == 'a/b/c'
+        assert RequestHelper().build_parameterized_url('a/{b}/c', b='test') == 'a/test/c'

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -106,7 +106,10 @@ class Mfa(object):
             raise ValueError("Incomplete arguments. Need to specify a factor ID")
 
         response = self.request_helper.request(
-            self.request_helper.build_parameterized_url("auth/factors/{authentication_factor_id}", authentication_factor_id=authentication_factor_id),
+            self.request_helper.build_parameterized_url(
+                "auth/factors/{authentication_factor_id}",
+                authentication_factor_id=authentication_factor_id,
+            ),
             method=REQUEST_METHOD_GET,
             token=workos.api_key,
         )
@@ -135,7 +138,10 @@ class Mfa(object):
             raise ValueError("Incomplete arguments. Need to specify a factor ID.")
 
         return self.request_helper.request(
-            self.request_helper.build_parameterized_url("auth/factors/{authentication_factor_id}", authentication_factor_id=authentication_factor_id),
+            self.request_helper.build_parameterized_url(
+                "auth/factors/{authentication_factor_id}",
+                authentication_factor_id=authentication_factor_id,
+            ),
             method=REQUEST_METHOD_DELETE,
             token=workos.api_key,
         )
@@ -165,7 +171,9 @@ class Mfa(object):
             )
 
         response = self.request_helper.request(
-            self.request_helper.build_parameterized_url("auth/factors/{factor_id}/challenge", factor_id=authentication_factor_id),
+            self.request_helper.build_parameterized_url(
+                "auth/factors/{factor_id}/challenge", factor_id=authentication_factor_id
+            ),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,
@@ -222,7 +230,10 @@ class Mfa(object):
             )
 
         response = self.request_helper.request(
-            self.request_helper.build_parameterized_url("auth/challenges/{challenge_id}/verify", challenge_id=authentication_challenge_id),
+            self.request_helper.build_parameterized_url(
+                "auth/challenges/{challenge_id}/verify",
+                challenge_id=authentication_challenge_id,
+            ),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -106,9 +106,7 @@ class Mfa(object):
             raise ValueError("Incomplete arguments. Need to specify a factor ID")
 
         response = self.request_helper.request(
-            "auth/factors/{authentication_factor_id}".format(
-                authentication_factor_id=authentication_factor_id
-            ),
+            self.request_helper.build_parameterized_url("auth/factors/{authentication_factor_id}", authentication_factor_id=authentication_factor_id),
             method=REQUEST_METHOD_GET,
             token=workos.api_key,
         )
@@ -137,9 +135,7 @@ class Mfa(object):
             raise ValueError("Incomplete arguments. Need to specify a factor ID.")
 
         return self.request_helper.request(
-            "auth/factors/{authentication_factor_id}".format(
-                authentication_factor_id=authentication_factor_id
-            ),
+            self.request_helper.build_parameterized_url("auth/factors/{authentication_factor_id}", authentication_factor_id=authentication_factor_id),
             method=REQUEST_METHOD_DELETE,
             token=workos.api_key,
         )
@@ -169,9 +165,7 @@ class Mfa(object):
             )
 
         response = self.request_helper.request(
-            "auth/factors/{factor_id}/challenge".format(
-                factor_id=authentication_factor_id
-            ),
+            self.request_helper.build_parameterized_url("auth/factors/{factor_id}/challenge", factor_id=authentication_factor_id),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,
@@ -228,9 +222,7 @@ class Mfa(object):
             )
 
         response = self.request_helper.request(
-            "auth/challenges/{challenge_id}/verify".format(
-                challenge_id=authentication_challenge_id
-            ),
+            self.request_helper.build_parameterized_url("auth/challenges/{challenge_id}/verify", challenge_id=authentication_challenge_id),
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -1,6 +1,7 @@
 import platform
 
 import requests
+import urllib
 
 import workos
 from workos.exceptions import (

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -45,6 +45,9 @@ class RequestHelper(object):
     def generate_api_url(self, path):
         return self.base_api_url.format(path)
 
+    def build_parameterized_url(self, url, **params):
+        return url.format(**params)
+
     def request(
         self,
         path,

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -46,7 +46,8 @@ class RequestHelper(object):
         return self.base_api_url.format(path)
 
     def build_parameterized_url(self, url, **params):
-        return url.format(**params)
+        escaped_params = {k: urllib.parse.quote(str(v)) for k, v in params.items()}
+        return url.format(**escaped_params)
 
     def request(
         self,


### PR DESCRIPTION
## Description
This is to ensure we have the right helpers (and test coverage) to build URLs in the right way, and not experience code defects as the ones reported recently.

