### PR TITLE
Add `organization_id` support for Events API

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -19,6 +19,7 @@ class TestEvents(object):
                 "params": {
                     "events": None,
                     "limit": None,
+                    "organization_id": None,
                     "after": None,
                     "range_start": None,
                     "range_end": None,
@@ -42,4 +43,16 @@ class TestEvents(object):
             events=["dsync.user.created"],
         )
 
+        assert events["metadata"]["params"]["events"] == ["dsync.user.created"]
+
+    def test_list_events_with_organization_id_returns_metadata(self, mock_events, mock_request_method):
+        mock_request_method("get", mock_events, 200)
+
+        events = self.events.list_events(
+            events=["dsync.user.created"],
+            organization_id="org_1234",
+        )
+
+
+        assert events["metadata"]["params"]["organization_id"] == "org_1234" 
         assert events["metadata"]["params"]["events"] == ["dsync.user.created"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -45,7 +45,9 @@ class TestEvents(object):
 
         assert events["metadata"]["params"]["events"] == ["dsync.user.created"]
 
-    def test_list_events_with_organization_id_returns_metadata(self, mock_events, mock_request_method):
+    def test_list_events_with_organization_id_returns_metadata(
+        self, mock_events, mock_request_method
+    ):
         mock_request_method("get", mock_events, 200)
 
         events = self.events.list_events(
@@ -53,6 +55,5 @@ class TestEvents(object):
             organization_id="org_1234",
         )
 
-
-        assert events["metadata"]["params"]["organization_id"] == "org_1234" 
+        assert events["metadata"]["params"]["organization_id"] == "org_1234"
         assert events["metadata"]["params"]["events"] == ["dsync.user.created"]

--- a/tests/utils/fixtures/mock_event.py
+++ b/tests/utils/fixtures/mock_event.py
@@ -7,10 +7,7 @@ class MockEvent(WorkOSBaseResource):
         self.object = "event"
         self.id = id
         self.event = "dsync.user.created"
-        self.data = {
-            "id": "event_01234ABCD",
-            "organization_id": "org_1234"
-        }
+        self.data = {"id": "event_01234ABCD", "organization_id": "org_1234"}
         self.created_at = datetime.datetime.now()
 
     OBJECT_FIELDS = [

--- a/tests/utils/fixtures/mock_event.py
+++ b/tests/utils/fixtures/mock_event.py
@@ -9,6 +9,7 @@ class MockEvent(WorkOSBaseResource):
         self.event = "dsync.user.created"
         self.data = {
             "id": "event_01234ABCD",
+            "organization_id": "org_1234"
         }
         self.created_at = datetime.datetime.now()
 

--- a/workos/events.py
+++ b/workos/events.py
@@ -28,6 +28,7 @@ class Events(WorkOSListResource):
         self,
         events=None,
         limit=None,
+        organization_id=None,
         after=None,
         range_start=None,
         range_end=None,
@@ -36,6 +37,7 @@ class Events(WorkOSListResource):
         Kwargs:
             events (list): Filter to only return events of particular types. (Optional)
             limit (int): Maximum number of records to return. (Optional)
+            organization_id(str): Organization ID limits scope of events to a single organization. (Optional)
             after (str): Pagination cursor to receive records after a provided Event ID. (Optional)
             range_start (str): Date range start for stream of events. (Optional)
             range_end (str): Date range end for stream of events. (Optional)
@@ -53,6 +55,7 @@ class Events(WorkOSListResource):
             "events": events,
             "limit": limit,
             "after": after,
+            "organization_id": organization_id,
             "range_start": range_start,
             "range_end": range_end,
         }


### PR DESCRIPTION
## Description
Support passing in `organization_id` as a valid parameter when calling the Events API 
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.