### PR TITLE
v4.5.0

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
## Description

Bumps the version to `v4.5.0` and releases the following changes:

* #257 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.