### PR TITLE
Add API changes for invitations and Magic Auth

### DIFF
--- a/tests/utils/fixtures/mock_invitation.py
+++ b/tests/utils/fixtures/mock_invitation.py
@@ -10,7 +10,10 @@ class MockInvitation(WorkOSBaseResource):
         self.accepted_at = None
         self.revoked_at = None
         self.expires_at = datetime.datetime.now()
-        self.token = "ABCDE12345"
+        self.token = "Z1uX3RbwcIl5fIGJJJCXXisdI"
+        self.accept_invitation_url = (
+            "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI"
+        )
         self.organization_id = "org_12345"
         self.created_at = datetime.datetime.now()
         self.updated_at = datetime.datetime.now()
@@ -23,6 +26,7 @@ class MockInvitation(WorkOSBaseResource):
         "revoked_at",
         "expires_at",
         "token",
+        "accept_invitation_url",
         "organization_id",
         "created_at",
         "updated_at",

--- a/tests/utils/fixtures/mock_magic_auth.py
+++ b/tests/utils/fixtures/mock_magic_auth.py
@@ -1,0 +1,23 @@
+import datetime
+from workos.resources.base import WorkOSBaseResource
+
+
+class MockMagicAuth(WorkOSBaseResource):
+    def __init__(self, id):
+        self.id = id
+        self.user_id = "user_01HWZBQAY251RZ9BKB4RZW4D4A"
+        self.email = "marcelina@foo-corp.com"
+        self.expires_at = datetime.datetime.now()
+        self.code = "123456"
+        self.created_at = datetime.datetime.now()
+        self.updated_at = datetime.datetime.now()
+
+    OBJECT_FIELDS = [
+        "id",
+        "user_id",
+        "email",
+        "expires_at",
+        "code",
+        "created_at",
+        "updated_at",
+    ]

--- a/workos/resources/user_management.py
+++ b/workos/resources/user_management.py
@@ -90,7 +90,26 @@ class WorkOSInvitation(WorkOSBaseResource):
         "revoked_at",
         "expires_at",
         "token",
+        "accept_invitation_url",
         "organization_id",
+        "created_at",
+        "updated_at",
+    ]
+
+
+class WorkOSMagicAuth(WorkOSBaseResource):
+    """Representation of a MagicAuth object as returned by WorkOS through User Management features.
+
+    Attributes:
+        OBJECT_FIELDS (list): List of fields a WorkOSMagicAuth comprises.
+    """
+
+    OBJECT_FIELDS = [
+        "id",
+        "user_id",
+        "email",
+        "expires_at",
+        "code",
         "created_at",
         "updated_at",
     ]


### PR DESCRIPTION
## Description

Adds events and API changes to support sending your own emails for invitations and Magic Auth.

- Adds `accept_invitation_url` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `get_magic_auth` and `create_magic_auth`
- Deprecates current `send_magic_auth_code` method in favor of `create_magic_auth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26691