### PR TITLE
v4.6.0

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.5.0"
+__version__ = "4.6.0"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
## Description
Adds API changes to support sending your own emails for invitations and Magic Auth.

- Adds `accept_invitation_url` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `get_magic_auth` and `create_magic_auth`
- Deprecates current `send_magic_auth_code` method in favor of `create_magic_auth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.