### PR TITLE
Add role to Directory Sync User object

### DIFF
--- a/tests/utils/fixtures/mock_directory_user.py
+++ b/tests/utils/fixtures/mock_directory_user.py
@@ -37,6 +37,9 @@ class MockDirectoryUser(WorkOSBaseResource):
             ],
         }
         self.object = "directory_user"
+        self.role = {
+            "slug": "member",
+        }
 
     OBJECT_FIELDS = [
         "id",
@@ -55,4 +58,5 @@ class MockDirectoryUser(WorkOSBaseResource):
         "custom_attributes",
         "raw_attributes",
         "object",
+        "role",
     ]

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.8.0"
+__version__ = "4.7.0"
 
 __author__ = "WorkOS"
 

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.7.0"
+__version__ = "4.8.0"
 
 __author__ = "WorkOS"
 

--- a/workos/resources/directory_sync.py
+++ b/workos/resources/directory_sync.py
@@ -85,7 +85,7 @@ class WorkOSDirectoryUser(WorkOSBaseResource):
         "custom_attributes",
         "raw_attributes",
         "object",
-        "role",
+        "role",  # [OPTIONAL]
     ]
 
     @classmethod

--- a/workos/resources/directory_sync.py
+++ b/workos/resources/directory_sync.py
@@ -85,6 +85,7 @@ class WorkOSDirectoryUser(WorkOSBaseResource):
         "custom_attributes",
         "raw_attributes",
         "object",
+        "role",
     ]
 
     @classmethod


### PR DESCRIPTION
## Description
Optional property on the directory sync user object.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.