### PR TITLE
Fig bug with JWKs and logout URL

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -865,13 +865,13 @@ class TestUserManagement(object):
         assert request["json"]["grant_type"] == "refresh_token"
 
     def test_get_jwks_url(self):
-        expected = "%s/sso/jwks/%s" % (workos.base_api_url, workos.client_id)
+        expected = "%ssso/jwks/%s" % (workos.base_api_url, workos.client_id)
         result = self.user_management.get_jwks_url()
 
         assert expected == result
 
     def test_get_logout_url(self):
-        expected = "%s/user_management/sessions/logout?session_id=%s" % (
+        expected = "%suser_management/sessions/logout?session_id=%s" % (
             workos.base_api_url,
             "session_123",
         )

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.7.0"
+__version__ = "4.7.1"
 
 __author__ = "WorkOS"
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -817,7 +817,7 @@ class UserManagement(WorkOSListResource):
             (str): The public JWKS URL.
         """
 
-        return "%s/sso/jwks/%s" % (workos.base_api_url, workos.client_id)
+        return "%ssso/jwks/%s" % (workos.base_api_url, workos.client_id)
 
     def get_logout_url(self, session_id):
         """Get the URL for ending the session and redirecting the user
@@ -829,7 +829,7 @@ class UserManagement(WorkOSListResource):
             (str): URL to redirect the user to to end the session.
         """
 
-        return "%s/user_management/sessions/logout?session_id=%s" % (
+        return "%suser_management/sessions/logout?session_id=%s" % (
             workos.base_api_url,
             session_id,
         )


### PR DESCRIPTION
## Description
Fix bug with trailing forward slash in JWKS and logout URLs.

Fixes https://github.com/workos/workos-python/issues/269


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.