### PR TITLE
Add AppleOAuth and GitHubOAuth constants

### DIFF
--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -437,7 +437,7 @@ class UserManagement(WorkOSListResource):
             organization_id (str) - The organization_id connection selector is used to initiate SSO for an Organization.
                 The value of this parameter should be a WorkOS Organization ID. (Optional)
             provider (UserManagementProviderType) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
-                Currently, the supported values for provider are 'authkit', 'GoogleOAuth' and 'MicrosoftOAuth'. (Optional)
+                Currently, the supported values for provider are 'authkit', 'AppleOAuth', 'GithubOAuth, 'GoogleOAuth', and 'MicrosoftOAuth'. (Optional)
             domain_hint (str) - Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
                 or with a GoogleSAML connection type. (Optional)
             login_hint (str) - Can be used to pre-fill the username/email address field of the IdP sign-in page for the user,

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -437,7 +437,7 @@ class UserManagement(WorkOSListResource):
             organization_id (str) - The organization_id connection selector is used to initiate SSO for an Organization.
                 The value of this parameter should be a WorkOS Organization ID. (Optional)
             provider (UserManagementProviderType) - The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
-                Currently, the supported values for provider are 'authkit', 'AppleOAuth', 'GithubOAuth, 'GoogleOAuth', and 'MicrosoftOAuth'. (Optional)
+                Currently, the supported values for provider are 'authkit', 'AppleOAuth', 'GitHubOAuth, 'GoogleOAuth', and 'MicrosoftOAuth'. (Optional)
             domain_hint (str) - Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
                 or with a GoogleSAML connection type. (Optional)
             login_hint (str) - Can be used to pre-fill the username/email address field of the IdP sign-in page for the user,

--- a/workos/utils/connection_types.py
+++ b/workos/utils/connection_types.py
@@ -4,6 +4,7 @@ from enum import Enum
 class ConnectionType(Enum):
     ADFSSAML = "ADFSSAML"
     AdpOidc = "AdpOidc"
+    AppleOAuth = "AppleOAuth"
     Auth0SAML = "Auth0SAML"
     AzureSAML = "AzureSAML"
     CasSAML = "CasSAML"
@@ -13,6 +14,7 @@ class ConnectionType(Enum):
     DuoSAML = "DuoSAML"
     GenericOIDC = "GenericOIDC"
     GenericSAML = "GenericSAML"
+    GithubOAuth = "GithubOAuth"
     GoogleOAuth = "GoogleOAuth"
     GoogleSAML = "GoogleSAML"
     JumpCloudSAML = "JumpCloudSAML"

--- a/workos/utils/connection_types.py
+++ b/workos/utils/connection_types.py
@@ -14,7 +14,7 @@ class ConnectionType(Enum):
     DuoSAML = "DuoSAML"
     GenericOIDC = "GenericOIDC"
     GenericSAML = "GenericSAML"
-    GithubOAuth = "GithubOAuth"
+    GitHubOAuth = "GitHubOAuth"
     GoogleOAuth = "GoogleOAuth"
     GoogleSAML = "GoogleSAML"
     JumpCloudSAML = "JumpCloudSAML"

--- a/workos/utils/sso_provider_types.py
+++ b/workos/utils/sso_provider_types.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class SsoProviderType(Enum):
+    AppleOAuth = "AppleOAuth"
     GitHubOAuth = "GitHubOAuth"
     GoogleOAuth = "GoogleOAuth"
     MicrosoftOAuth = "MicrosoftOAuth"

--- a/workos/utils/um_provider_types.py
+++ b/workos/utils/um_provider_types.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class UserManagementProviderType(Enum):
     AuthKit = "authkit"
+    AppleOAuth = "AppleOAuth"
     GitHubOAuth = "GitHubOAuth"
     GoogleOAuth = "GoogleOAuth"
     MicrosoftOAuth = "MicrosoftOAuth"


### PR DESCRIPTION
## Description
Add `AppleOAuth` constants so SDK users can kick off login flows with Sign in with Apple.

The `ConnectionType.GitHubOAuth` constant was never added to this SDK, adding it too.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.