### PR TITLE
Add `lookup_key` support

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -185,6 +185,15 @@ class TestOrganizations(object):
 
         assert organization == mock_organization
 
+    def test_get_organization_by_lookup_key(self, mock_organization, mock_request_method):
+        mock_request_method("get", mock_organization, 200)
+
+        organization = self.organizations.get_organization_by_lookup_key(
+            lookup_key="test"
+        )
+
+        assert organization == mock_organization
+
     def test_create_organization_with_domain_data(
         self, mock_organization, mock_request_method
     ):

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -185,7 +185,9 @@ class TestOrganizations(object):
 
         assert organization == mock_organization
 
-    def test_get_organization_by_lookup_key(self, mock_organization, mock_request_method):
+    def test_get_organization_by_lookup_key(
+        self, mock_organization, mock_request_method
+    ):
         mock_request_method("get", mock_organization, 200)
 
         organization = self.organizations.get_organization_by_lookup_key(

--- a/tests/utils/fixtures/mock_organization.py
+++ b/tests/utils/fixtures/mock_organization.py
@@ -26,4 +26,5 @@ class MockOrganization(WorkOSBaseResource):
         "created_at",
         "updated_at",
         "domains",
+        "lookup_key",
     ]

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -179,7 +179,7 @@ class Organizations(WorkOSListResource):
         response = self.request_helper.request(
             "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
             method=REQUEST_METHOD_GET,
-            token=workos.api_key
+            token=workos.api_key,
         )
 
         return WorkOSOrganization.construct_from_response(response).to_dict()

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -169,6 +169,21 @@ class Organizations(WorkOSListResource):
 
         return WorkOSOrganization.construct_from_response(response).to_dict()
 
+    def get_organization_by_lookup_key(self, lookup_key):
+        """Gets details for a single Organization by lookup key
+        Args:
+            lookup_key (str): Organization's lookup key
+        Returns:
+            dict: Organization response from WorkOS
+        """
+        response = self.request_helper.request(
+            "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
+            method=REQUEST_METHOD_GET,
+            token=workos.api_key
+        )
+
+        return WorkOSOrganization.construct_from_response(response).to_dict()
+
     def create_organization(self, organization, idempotency_key=None):
         """Create an organization
 
@@ -222,6 +237,7 @@ class Organizations(WorkOSListResource):
         allow_profiles_outside_organization=None,
         domains=None,
         domain_data=None,
+        lookup_key=None,
     ):
         """Update an organization
 
@@ -261,6 +277,9 @@ class Organizations(WorkOSListResource):
 
         if domain_data is not None:
             params["domain_data"] = domain_data
+
+        if lookup_key is not None:
+            params["lookup_key"] = lookup_key
 
         response = self.request_helper.request(
             "organizations/{organization}".format(organization=organization),

--- a/workos/resources/organizations.py
+++ b/workos/resources/organizations.py
@@ -16,6 +16,7 @@ class WorkOSOrganization(WorkOSBaseResource):
         "created_at",
         "updated_at",
         "domains",
+        "lookup_key",
     ]
 
     @classmethod


### PR DESCRIPTION
## Description

NOTE: the lookup_key feature is not generally available right now.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
