### PR TITLE
Deprecate `allow_profiles_outside_organization` parameter

### DIFF
--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -255,9 +255,9 @@ class Organizations(WorkOSListResource):
                 "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
-            params["allow_profiles_outside_organization"] = (
-                allow_profiles_outside_organization
-            )
+            params[
+                "allow_profiles_outside_organization"
+            ] = allow_profiles_outside_organization
 
         if domain_data:
             params["domain_data"] = domain_data

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -239,25 +239,27 @@ class Organizations(WorkOSListResource):
         Returns:
             dict: Updated Organization response from WorkOS.
         """
+
+        params = { "name": name }
+
         if domains:
             warn(
                 "The 'domains' parameter for 'update_organization' is deprecated. Please use 'domain_data' instead.",
                 DeprecationWarning,
             )
+            params["domains"] = domains
 
-        if "allow_profiles_outside_organization" in organization:
+        if allow_profiles_outside_organization:
             warn(
                 "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "\
                 "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
+            params["allow_profiles_outside_organization"] = allow_profiles_outside_organization
 
-        params = {
-            "name": name,
-            "domains": domains,
-            "domain_data": domain_data,
-            "allow_profiles_outside_organization": allow_profiles_outside_organization,
-        }
+        if domain_data:
+            params["domain_data"] = domain_data
+
         response = self.request_helper.request(
             "organizations/{organization}".format(organization=organization),
             method=REQUEST_METHOD_PUT,

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -242,14 +242,14 @@ class Organizations(WorkOSListResource):
 
         params = {"name": name}
 
-        if domains:
+        if domains is not None:
             warn(
                 "The 'domains' parameter for 'update_organization' is deprecated. Please use 'domain_data' instead.",
                 DeprecationWarning,
             )
             params["domains"] = domains
 
-        if allow_profiles_outside_organization:
+        if allow_profiles_outside_organization is not None:
             warn(
                 "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "
                 "If you need to allow sign-ins from any email domain, contact support@workos.com.",
@@ -259,7 +259,7 @@ class Organizations(WorkOSListResource):
                 "allow_profiles_outside_organization"
             ] = allow_profiles_outside_organization
 
-        if domain_data:
+        if domain_data is not None:
             params["domain_data"] = domain_data
 
         response = self.request_helper.request(

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -175,9 +175,11 @@ class Organizations(WorkOSListResource):
         Args:
             organization (dict) - An organization object
                 organization[name] (str) - A unique, descriptive name for the organization
-                organization[allow_profiles_outside_organization] (boolean) - Whether Connections
+                organization[allow_profiles_outside_organization] (boolean) - [Deprecated] Whether Connections
                     within the Organization allow profiles that are outside of the Organization's
                     configured User Email Domains. (Optional)
+                organization[domains] (list[dict]) - [Deprecated] Use domain_data instead. List of domains that
+                    belong to the organization. (Optional)
                 organization[domain_data] (list[dict]) - List of domains that belong to the organization.
                     organization[domain_data][][domain] - The domain of the organization.
                     organization[domain_data][][state] - The state of the domain: either 'verified' or 'pending'.
@@ -193,6 +195,13 @@ class Organizations(WorkOSListResource):
         if "domains" in organization:
             warn(
                 "The 'domains' parameter for 'create_organization' is deprecated. Please use 'domain_data' instead.",
+                DeprecationWarning,
+            )
+
+        if "allow_profiles_outside_organization" in organization:
+            warn(
+                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "\
+                "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
 
@@ -219,7 +228,7 @@ class Organizations(WorkOSListResource):
         Args:
             organization(str) - Organization's unique identifier.
             name (str) - A unique, descriptive name for the organization.
-            allow_profiles_outside_organization (boolean) - Whether Connections
+            allow_profiles_outside_organization (boolean) - [Deprecated] Whether Connections
                 within the Organization allow profiles that are outside of the Organization's
                 configured User Email Domains. (Optional)
             domains (list) - [Deprecated] Use domain_data instead. List of domains that belong to the organization. (Optional)
@@ -233,6 +242,13 @@ class Organizations(WorkOSListResource):
         if domains:
             warn(
                 "The 'domains' parameter for 'update_organization' is deprecated. Please use 'domain_data' instead.",
+                DeprecationWarning,
+            )
+
+        if "allow_profiles_outside_organization" in organization:
+            warn(
+                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "\
+                "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
 

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -200,7 +200,7 @@ class Organizations(WorkOSListResource):
 
         if "allow_profiles_outside_organization" in organization:
             warn(
-                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "\
+                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "
                 "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
@@ -240,7 +240,7 @@ class Organizations(WorkOSListResource):
             dict: Updated Organization response from WorkOS.
         """
 
-        params = { "name": name }
+        params = {"name": name}
 
         if domains:
             warn(
@@ -251,11 +251,13 @@ class Organizations(WorkOSListResource):
 
         if allow_profiles_outside_organization:
             warn(
-                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "\
+                "The `allow_profiles_outside_organization` parameter for `create_orgnaization` is deprecated. "
                 "If you need to allow sign-ins from any email domain, contact support@workos.com.",
                 DeprecationWarning,
             )
-            params["allow_profiles_outside_organization"] = allow_profiles_outside_organization
+            params["allow_profiles_outside_organization"] = (
+                allow_profiles_outside_organization
+            )
 
         if domain_data:
             params["domain_data"] = domain_data

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -1159,17 +1159,17 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge[
-            "authentication_factor"
-        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
-            response["authentication_factor"]
-        ).to_dict()
+        factor_and_challenge["authentication_factor"] = (
+            WorkOSAuthenticationFactorTotp.construct_from_response(
+                response["authentication_factor"]
+            ).to_dict()
+        )
 
-        factor_and_challenge[
-            "authentication_challenge"
-        ] = WorkOSChallenge.construct_from_response(
-            response["authentication_challenge"]
-        ).to_dict()
+        factor_and_challenge["authentication_challenge"] = (
+            WorkOSChallenge.construct_from_response(
+                response["authentication_challenge"]
+            ).to_dict()
+        )
 
         return factor_and_challenge
 

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -1159,17 +1159,17 @@ class UserManagement(WorkOSListResource):
         )
 
         factor_and_challenge = {}
-        factor_and_challenge["authentication_factor"] = (
-            WorkOSAuthenticationFactorTotp.construct_from_response(
-                response["authentication_factor"]
-            ).to_dict()
-        )
+        factor_and_challenge[
+            "authentication_factor"
+        ] = WorkOSAuthenticationFactorTotp.construct_from_response(
+            response["authentication_factor"]
+        ).to_dict()
 
-        factor_and_challenge["authentication_challenge"] = (
-            WorkOSChallenge.construct_from_response(
-                response["authentication_challenge"]
-            ).to_dict()
-        )
+        factor_and_challenge[
+            "authentication_challenge"
+        ] = WorkOSChallenge.construct_from_response(
+            response["authentication_challenge"]
+        ).to_dict()
 
         return factor_and_challenge
 


### PR DESCRIPTION
## Description

Deprecates the `allow_profiles_outside_organization` parameter. Additionally, updates the create/update Organization methods to only serialize these options if an actual value has been passed.

Previously, `null` was always sent, which was fine for this particular endpoint, but is not a pattern that is guaranteed to have the same semantics everywhere.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.