### PR TITLE
update list_users function documentation on UserManagement class

### DIFF
--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -109,7 +109,7 @@ class UserManagement(WorkOSListResource):
             order (Order): Sort records in either ascending or descending order by created_at timestamp: "asc" or "desc" (Optional)
 
         Returns:
-            dict: Users response from WorkOS.
+            UserManagement: Users response from WorkOS. Call `to_dict()` or `auto_paging_iter()` to access the data.
         """
 
         default_limit = None


### PR DESCRIPTION
## Description

Had issues using the returned value from `list_users` on the `UserManagement` class, returned values was not a `dict` as described in the function docstring. 

Was going to modify the `list_users` return value in this PR, but then realised with the tests that a documented use case of `auto_paging_iter()` was is expected, as such the documentation should be updated to minimise developer confusion.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.