### PR TITLE
List resource returns more specific type

### DIFF
--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -16,6 +16,7 @@ from workos.resources.directory_sync import (
 )
 from workos.resources.list import (
     ListArgs,
+    ListMetadata,
     ListPage,
     AsyncWorkOsListResource,
     SyncOrAsyncListResource,
@@ -100,7 +101,9 @@ class DirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[DirectoryUserWithGroups, DirectoryUserListFilters]:
+    ) -> WorkOsListResource[
+        DirectoryUserWithGroups, DirectoryUserListFilters, ListMetadata
+    ]:
         """Gets a list of provisioned Users for a Directory.
 
         Note, either 'directory' or 'group' must be provided.
@@ -150,7 +153,7 @@ class DirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[DirectoryGroup, DirectoryGroupListFilters]:
+    ) -> WorkOsListResource[DirectoryGroup, DirectoryGroupListFilters, ListMetadata]:
         """Gets a list of provisioned Groups for a Directory .
 
         Note, either 'directory' or 'user' must be provided.
@@ -252,7 +255,7 @@ class DirectorySync(DirectorySyncModule):
         after: Optional[str] = None,
         organization: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Directory, DirectoryListFilters]:
+    ) -> WorkOsListResource[Directory, DirectoryListFilters, ListMetadata]:
         """Gets details for existing Directories.
 
         Args:
@@ -323,7 +326,9 @@ class AsyncDirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[DirectoryUserWithGroups, DirectoryUserListFilters]:
+    ) -> AsyncWorkOsListResource[
+        DirectoryUserWithGroups, DirectoryUserListFilters, ListMetadata
+    ]:
         """Gets a list of provisioned Users for a Directory.
 
         Note, either 'directory' or 'group' must be provided.
@@ -373,7 +378,9 @@ class AsyncDirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[DirectoryGroup, DirectoryGroupListFilters]:
+    ) -> AsyncWorkOsListResource[
+        DirectoryGroup, DirectoryGroupListFilters, ListMetadata
+    ]:
         """Gets a list of provisioned Groups for a Directory .
 
         Note, either 'directory' or 'user' must be provided.
@@ -474,7 +481,7 @@ class AsyncDirectorySync(DirectorySyncModule):
         after: Optional[str] = None,
         organization: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[Directory, DirectoryListFilters]:
+    ) -> AsyncWorkOsListResource[Directory, DirectoryListFilters, ListMetadata]:
         """Gets details for existing Directories.
 
         Args:

--- a/workos/events.py
+++ b/workos/events.py
@@ -7,6 +7,7 @@ from workos.resources.events import Event, EventType
 from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
 from workos.utils.validation import EVENTS_MODULE, validate_settings
 from workos.resources.list import (
+    ListAfterMetadata,
     ListArgs,
     ListPage,
     WorkOsListResource,
@@ -20,7 +21,7 @@ class EventsListFilters(ListArgs, total=False):
     range_end: Optional[str]
 
 
-EventsListResource = WorkOsListResource[Event, EventsListFilters]
+EventsListResource = WorkOsListResource[Event, EventsListFilters, ListAfterMetadata]
 
 
 class EventsModule(Protocol):

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -14,7 +14,7 @@ from workos.resources.organizations import (
     Organization,
     DomainDataInput,
 )
-from workos.resources.list import ListPage, WorkOsListResource, ListArgs
+from workos.resources.list import ListMetadata, ListPage, WorkOsListResource, ListArgs
 
 ORGANIZATIONS_PATH = "organizations"
 
@@ -31,7 +31,7 @@ class OrganizationsModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Organization, OrganizationListFilters]: ...
+    ) -> WorkOsListResource[Organization, OrganizationListFilters, ListMetadata]: ...
 
     def get_organization(self, organization: str) -> Organization: ...
 
@@ -72,7 +72,7 @@ class Organizations(OrganizationsModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Organization, OrganizationListFilters]:
+    ) -> WorkOsListResource[Organization, OrganizationListFilters, ListMetadata]:
         """Retrieve a list of organizations that have connections configured within your WorkOS dashboard.
 
         Kwargs:
@@ -101,7 +101,7 @@ class Organizations(OrganizationsModule):
             token=workos.api_key,
         )
 
-        return WorkOsListResource[Organization, OrganizationListFilters](
+        return WorkOsListResource[Organization, OrganizationListFilters, ListMetadata](
             list_method=self.list_organizations,
             list_args=list_params,
             **ListPage[Organization](**response).model_dump()

--- a/workos/resources/list.py
+++ b/workos/resources/list.py
@@ -139,6 +139,9 @@ class ListMetadata(ListAfterMetadata):
     before: Optional[str] = None
 
 
+ListMetadataType = TypeVar("ListMetadataType", ListAfterMetadata, ListMetadata)
+
+
 class ListPage(WorkOSModel, Generic[ListableResource]):
     object: Literal["list"]
     data: List[ListableResource]
@@ -158,11 +161,11 @@ ListMetadataType = TypeVar("ListMetadataType", ListAfterMetadata, ListMetadata)
 
 class BaseWorkOsListResource(
     WorkOSModel,
-    Generic[ListableResource, ListAndFilterParams],
+    Generic[ListableResource, ListAndFilterParams, ListMetadataType],
 ):
     object: Literal["list"]
     data: List[ListableResource]
-    list_metadata: Union[ListAfterMetadata, ListMetadata]
+    list_metadata: ListMetadataType
 
     list_method: Callable = Field(exclude=True)
     list_args: ListAndFilterParams = Field(exclude=True)
@@ -195,10 +198,12 @@ class BaseWorkOsListResource(
 
 class WorkOsListResource(
     BaseWorkOsListResource,
-    Generic[ListableResource, ListAndFilterParams],
+    Generic[ListableResource, ListAndFilterParams, ListMetadataType],
 ):
     def auto_paging_iter(self) -> Iterator[ListableResource]:
-        next_page: WorkOsListResource[ListableResource, ListAndFilterParams]
+        next_page: WorkOsListResource[
+            ListableResource, ListAndFilterParams, ListMetadataType
+        ]
         after = self.list_metadata.after
         fixed_pagination_params, filter_params = self._parse_params()
         index: int = 0
@@ -221,10 +226,12 @@ class WorkOsListResource(
 
 class AsyncWorkOsListResource(
     BaseWorkOsListResource,
-    Generic[ListableResource, ListAndFilterParams],
+    Generic[ListableResource, ListAndFilterParams, ListMetadataType],
 ):
     async def auto_paging_iter(self) -> AsyncIterator[ListableResource]:
-        next_page: WorkOsListResource[ListableResource, ListAndFilterParams]
+        next_page: WorkOsListResource[
+            ListableResource, ListAndFilterParams, ListMetadataType
+        ]
         after = self.list_metadata.after
         fixed_pagination_params, filter_params = self._parse_params()
         index: int = 0

--- a/workos/resources/list.py
+++ b/workos/resources/list.py
@@ -156,7 +156,6 @@ class ListArgs(TypedDict, total=False):
 
 
 ListAndFilterParams = TypeVar("ListAndFilterParams", bound=ListArgs)
-ListMetadataType = TypeVar("ListMetadataType", ListAfterMetadata, ListMetadata)
 
 
 class BaseWorkOsListResource(

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -23,6 +23,7 @@ from workos.utils.validation import SSO_MODULE, validate_settings
 from workos.resources.list import (
     AsyncWorkOsListResource,
     ListArgs,
+    ListMetadata,
     ListPage,
     SyncOrAsyncListResource,
     WorkOsListResource,
@@ -194,7 +195,7 @@ class SSO(SSOModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Connection, ConnectionsListFilters]:
+    ) -> WorkOsListResource[Connection, ConnectionsListFilters, ListMetadata]:
         """Gets details for existing Connections.
 
         Args:
@@ -321,7 +322,7 @@ class AsyncSSO(SSOModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[Connection, ConnectionsListFilters]:
+    ) -> AsyncWorkOsListResource[Connection, ConnectionsListFilters, ListMetadata]:
         """Gets details for existing Connections.
 
         Args:


### PR DESCRIPTION
## Description
Making this a union was the wrong choice. It requires the developer to handle the scenario where `before` does not exist in the dictionary for all list resources. It's only the case for Events.

This type var lets us return the correct type for each resource.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.