### PR TITLE
Add `organization_id` parameter to `authenticate_with_refresh_token`

### DIFF
--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -780,6 +780,7 @@ class UserManagement(WorkOSListResource):
     def authenticate_with_refresh_token(
         self,
         refresh_token,
+        organization_id=None,
         ip_address=None,
         user_agent=None,
     ):
@@ -787,6 +788,7 @@ class UserManagement(WorkOSListResource):
 
         Kwargs:
             refresh_token (str): The token associated to the user.
+            organization_id (str): The organization to issue the new access token for. (Optional)
             ip_address (str): The IP address of the request from the user who is attempting to authenticate. (Optional)
             user_agent (str): The user agent of the request from the user who is attempting to authenticate. (Optional)
 
@@ -804,6 +806,9 @@ class UserManagement(WorkOSListResource):
             "refresh_token": refresh_token,
             "grant_type": "refresh_token",
         }
+
+        if organization_id:
+            payload["organization_id"] = organization_id
 
         if ip_address:
             payload["ip_address"] = ip_address


### PR DESCRIPTION
## Description

Adds the new `organization_id` parameter to the User Management `authenticate_with_refresh_token` method.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.