### PR TITLE
Add typing for portal

### DIFF
--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,49 +1,55 @@
-import json
-from requests import Response
-
 import pytest
 
-import workos
 from workos.portal import Portal
+from workos.utils.http_client import SyncHTTPClient
 
 
 class TestPortal(object):
     @pytest.fixture(autouse=True)
     def setup(self, set_api_key):
-        self.portal = Portal()
+        self.http_client = SyncHTTPClient(
+            base_url="https://api.workos.test", version="test"
+        )
+        self.portal = Portal(http_client=self.http_client)
 
     @pytest.fixture
     def mock_portal_link(self):
         return {"link": "https://id.workos.com/portal/launch?secret=secret"}
 
-    def test_generate_link_sso(self, mock_portal_link, mock_request_method):
-        mock_request_method("post", mock_portal_link, 201)
+    def test_generate_link_sso(self, mock_portal_link, mock_http_client_with_response):
+        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link("sso", "org_01EHQMYV6MBK39QC5PZXHY59C3")
 
-        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
-    def test_generate_link_dsync(self, mock_portal_link, mock_request_method):
-        mock_request_method("post", mock_portal_link, 201)
+    def test_generate_link_dsync(
+        self, mock_portal_link, mock_http_client_with_response
+    ):
+        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link("dsync", "org_01EHQMYV6MBK39QC5PZXHY59C3")
 
-        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
-    def test_generate_link_audit_logs(self, mock_portal_link, mock_request_method):
-        mock_request_method("post", mock_portal_link, 201)
+    def test_generate_link_audit_logs(
+        self, mock_portal_link, mock_http_client_with_response
+    ):
+        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link(
             "audit_logs", "org_01EHQMYV6MBK39QC5PZXHY59C3"
         )
 
-        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
-    def test_generate_link_log_streams(self, mock_portal_link, mock_request_method):
-        mock_request_method("post", mock_portal_link, 201)
+    def test_generate_link_log_streams(
+        self, mock_portal_link, mock_http_client_with_response
+    ):
+        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link(
             "log_streams", "org_01EHQMYV6MBK39QC5PZXHY59C3"
         )
 
-        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response.link == "https://id.workos.com/portal/launch?secret=secret"

--- a/workos/client.py
+++ b/workos/client.py
@@ -49,7 +49,7 @@ class SyncClient(BaseClient):
     @property
     def organizations(self):
         if not getattr(self, "_organizations", None):
-            self._organizations = Organizations()
+            self._organizations = Organizations(self._http_client)
         return self._organizations
 
     @property
@@ -61,7 +61,7 @@ class SyncClient(BaseClient):
     @property
     def portal(self):
         if not getattr(self, "_portal", None):
-            self._portal = Portal()
+            self._portal = Portal(self._http_client)
         return self._portal
 
     @property

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -1,9 +1,9 @@
 from typing import List, Optional, Protocol
 import workos
+from workos.utils.http_client import SyncHTTPClient
 from workos.utils.pagination_order import PaginationOrder
 from workos.utils.request import (
     DEFAULT_LIST_RESPONSE_LIMIT,
-    RequestHelper,
     REQUEST_METHOD_DELETE,
     REQUEST_METHOD_GET,
     REQUEST_METHOD_POST,
@@ -55,15 +55,12 @@ class OrganizationsModule(Protocol):
 
 
 class Organizations(OrganizationsModule):
-    @validate_settings(ORGANIZATIONS_MODULE)
-    def __init__(self):
-        pass
 
-    @property
-    def request_helper(self):
-        if not getattr(self, "_request_helper", None):
-            self._request_helper = RequestHelper()
-        return self._request_helper
+    _http_client: SyncHTTPClient
+
+    @validate_settings(ORGANIZATIONS_MODULE)
+    def __init__(self, http_client: SyncHTTPClient):
+        self._http_client = http_client
 
     def list_organizations(
         self,
@@ -94,7 +91,7 @@ class Organizations(OrganizationsModule):
             "domains": domains,
         }
 
-        response = self.request_helper.request(
+        response = self._http_client.request(
             ORGANIZATIONS_PATH,
             method=REQUEST_METHOD_GET,
             params=list_params,
@@ -114,7 +111,7 @@ class Organizations(OrganizationsModule):
         Returns:
             dict: Organization response from WorkOS
         """
-        response = self.request_helper.request(
+        response = self._http_client.request(
             "organizations/{organization}".format(organization=organization),
             method=REQUEST_METHOD_GET,
             token=workos.api_key,
@@ -129,7 +126,7 @@ class Organizations(OrganizationsModule):
         Returns:
             dict: Organization response from WorkOS
         """
-        response = self.request_helper.request(
+        response = self._http_client.request(
             "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
             method=REQUEST_METHOD_GET,
             token=workos.api_key,
@@ -154,7 +151,7 @@ class Organizations(OrganizationsModule):
             "idempotency_key": idempotency_key,
         }
 
-        response = self.request_helper.request(
+        response = self._http_client.request(
             ORGANIZATIONS_PATH,
             method=REQUEST_METHOD_POST,
             params=params,
@@ -175,7 +172,7 @@ class Organizations(OrganizationsModule):
             "domain_data": domain_data,
         }
 
-        response = self.request_helper.request(
+        response = self._http_client.request(
             "organizations/{organization}".format(organization=organization),
             method=REQUEST_METHOD_PUT,
             params=params,
@@ -190,7 +187,7 @@ class Organizations(OrganizationsModule):
         Args:
             organization (str): Organization unique identifier
         """
-        return self.request_helper.request(
+        return self._http_client.request(
             "organizations/{organization}".format(organization=organization),
             method=REQUEST_METHOD_DELETE,
             token=workos.api_key,

--- a/workos/portal.py
+++ b/workos/portal.py
@@ -1,7 +1,9 @@
-from typing import Literal, Optional, Protocol
+from typing import Optional, Protocol
 
 import workos
-from workos.utils.request import RequestHelper, REQUEST_METHOD_POST
+from workos.resources.portal import PortalLink, PortalLinkIntent
+from workos.utils.http_client import SyncHTTPClient
+from workos.utils.request import REQUEST_METHOD_POST
 from workos.utils.validation import PORTAL_MODULE, validate_settings
 
 
@@ -11,53 +13,52 @@ PORTAL_GENERATE_PATH = "portal/generate_link"
 class PortalModule(Protocol):
     def generate_link(
         self,
-        intent: Literal["audit_logs", "dsync", "log_streams", "sso"],
-        organization: str,
+        intent: PortalLinkIntent,
+        organization_id: str,
         return_url: Optional[str] = None,
         success_url: Optional[str] = None,
-    ) -> dict: ...
+    ) -> PortalLink: ...
 
 
 class Portal(PortalModule):
-    @validate_settings(PORTAL_MODULE)
-    def __init__(self):
-        pass
 
-    @property
-    def request_helper(self):
-        if not getattr(self, "_request_helper", None):
-            self._request_helper = RequestHelper()
-        return self._request_helper
+    _http_client: SyncHTTPClient
+
+    @validate_settings(PORTAL_MODULE)
+    def __init__(self, http_client: SyncHTTPClient):
+        self._http_client = http_client
 
     def generate_link(
         self,
-        intent: Literal["audit_logs", "dsync", "log_streams", "sso"],
-        organization: str,
+        intent: PortalLinkIntent,
+        organization_id: str,
         return_url: Optional[str] = None,
         success_url: Optional[str] = None,
-    ):
+    ) -> PortalLink:
         """Generate a link to grant access to an organization's Admin Portal
 
         Args:
             intent (str): The access scope for the generated Admin Portal link. Valid values are: ["audit_logs", "dsync", "log_streams", "sso",]
-            organization (string): The ID of the organization the Admin Portal link will be generated for
+            organization_id (string): The ID of the organization the Admin Portal link will be generated for
 
         Kwargs:
             return_url (str): The URL that the end user will be redirected to upon exiting the generated Admin Portal. If none is provided, the default redirect link set in your WorkOS Dashboard will be used. (Optional)
             success_url (str): The URL to which WorkOS will redirect users to upon successfully viewing Audit Logs, setting up Log Streams, Single Sign On or Directory Sync. (Optional)
 
         Returns:
-            str:  URL to redirect a User to to access an Admin Portal session
+            PortalLink: PortalLink object with URL to redirect a User to to access an Admin Portal session
         """
         params = {
             "intent": intent,
-            "organization": organization,
+            "organization": organization_id,
             "return_url": return_url,
             "success_url": success_url,
         }
-        return self.request_helper.request(
+        response = self._http_client.request(
             PORTAL_GENERATE_PATH,
             method=REQUEST_METHOD_POST,
             params=params,
             token=workos.api_key,
         )
+
+        return PortalLink.model_validate(response)

--- a/workos/resources/portal.py
+++ b/workos/resources/portal.py
@@ -1,0 +1,10 @@
+from typing import Literal
+from workos.resources.workos_model import WorkOSModel
+
+PortalLinkIntent = Literal["audit_logs", "dsync", "log_streams", "sso"]
+
+
+class PortalLink(WorkOSModel):
+    """Representation of an WorkOS generate portal link response."""
+
+    link: str


### PR DESCRIPTION
## Description
Add typing for portal and use new HTTP client for organizations.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.