### PR TITLE
Update release.yml to support pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Release
 on:
   # Support manually pushing a new release
   workflow_dispatch: {}
-  # Trigger when a release is published
+  # Trigger when a release or pre-release is published
   release:
-    types: [released]
+    types: [published]
 
 defaults:
   run:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: setup.py
 
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
       - name: Publish
         env:
           TWINE_NON_INTERACTIVE: true
-          TWINE_USERNAME: '__token__'
+          TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
## Description
Update release.yml to support pre-releases.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.