### PR TITLE
Fix sso profile resource

### DIFF
--- a/workos/resources/mfa.py
+++ b/workos/resources/mfa.py
@@ -45,14 +45,14 @@ class AuthenticationFactorTotp(AuthenticationFactorBase):
     """Representation of a MFA Authentication Factor Response as returned by WorkOS through the MFA feature."""
 
     type: TotpAuthenticationFactorType
-    totp: Union[TotpFactor, ExtendedTotpFactor, None]
+    totp: Union[TotpFactor, ExtendedTotpFactor, None] = None
 
 
 class AuthenticationFactorSms(AuthenticationFactorBase):
     """Representation of a SMS Authentication Factor Response as returned by WorkOS through the MFA feature."""
 
     type: SmsAuthenticationFactorType
-    sms: Union[SmsFactor, None]
+    sms: Union[SmsFactor, None] = None
 
 
 AuthenticationFactor = Union[AuthenticationFactorTotp, AuthenticationFactorSms]

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -16,7 +16,7 @@ class Profile(WorkOSModel):
     first_name: Union[str, None]
     last_name: Union[str, None]
     idp_id: str
-    groups: Union[Sequence[str], None]
+    groups: Union[Sequence[str], None] = None
     raw_attributes: dict
 
 

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -1,4 +1,4 @@
-from typing import Literal, Sequence, Union
+from typing import Literal, Optional, Sequence, Union
 from workos.resources.workos_model import WorkOSModel
 from workos.types.sso.connection import Connection, ConnectionType
 from workos.typing.literals import LiteralOrUntyped
@@ -11,12 +11,12 @@ class Profile(WorkOSModel):
     id: str
     connection_id: str
     connection_type: LiteralOrUntyped[ConnectionType]
-    organization_id: Union[str, None]
+    organization_id: Optional[str] = None
     email: str
-    first_name: Union[str, None]
-    last_name: Union[str, None]
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
     idp_id: str
-    groups: Union[Sequence[str], None] = None
+    groups: Optional[Sequence[str]] = None
     raw_attributes: dict
 
 

--- a/workos/types/events/authentication_payload.py
+++ b/workos/types/events/authentication_payload.py
@@ -1,10 +1,10 @@
-from typing import Literal, Union
+from typing import Literal, Optional
 from workos.resources.workos_model import WorkOSModel
 
 
 class AuthenticationResultCommon(WorkOSModel):
-    ip_address: Union[str, None]
-    user_agent: Union[str, None]
+    ip_address: Optional[str] = None
+    user_agent: Optional[str] = None
     email: str
     created_at: str
 
@@ -58,4 +58,4 @@ class AuthenticationPasswordSucceededPayload(AuthenticationResultSucceeded):
 
 class AuthenticationSsoSucceededPayload(AuthenticationResultSucceeded):
     type: Literal["sso"]
-    user_id: Union[str, None]
+    user_id: Optional[str] = None


### PR DESCRIPTION
## Description
Optional fields must have a default value, otherwise they result in an error and deserialization when there is no value for that attributes. Also, switched over to using `Optional` for consistency. Also fine with switching everything to `Union[FOO, None]`, but I think we should consistently use one style.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.