### PR TITLE
Remove need to call `auto_paging_iter` and use single WorkOsListResource for sync and async

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def test_sync_auto_pagination(
         results = list_function(**list_function_params or {})
         all_results = []
 
-        for result in results.auto_paging_iter():
+        for result in results:
             all_results.append(result)
 
         assert len(list(all_results)) == len(expected_all_page_data)

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.conftest import test_sync_auto_pagination
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from workos.directory_sync import AsyncDirectorySync, DirectorySync
 from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
@@ -248,92 +249,30 @@ class TestDirectorySync(DirectorySyncFixtures):
         assert me == None
 
     def test_list_directories_auto_pagination(
-        self,
-        mock_directories_multiple_data_pages,
-        mock_pagination_request_for_http_client,
+        self, mock_directories_multiple_data_pages, test_sync_auto_pagination
     ):
-        mock_pagination_request_for_http_client(
+        test_sync_auto_pagination(
             http_client=self.http_client,
-            data_list=mock_directories_multiple_data_pages,
-            status_code=200,
-        )
-
-        directories = self.directory_sync.list_directories()
-        all_directories = []
-
-        for directory in directories.auto_paging_iter():
-            all_directories.append(directory)
-
-        assert len(list(all_directories)) == len(mock_directories_multiple_data_pages)
-        assert (list_data_to_dicts(all_directories)) == api_directories_to_sdk(
-            mock_directories_multiple_data_pages
+            list_function=self.directory_sync.list_directories,
+            expected_all_page_data=mock_directories_multiple_data_pages,
         )
 
     def test_directory_users_auto_pagination(
-        self,
-        mock_directory_users_multiple_data_pages,
-        mock_pagination_request_for_http_client,
+        self, mock_directory_users_multiple_data_pages, test_sync_auto_pagination
     ):
-        mock_pagination_request_for_http_client(
+        test_sync_auto_pagination(
             http_client=self.http_client,
-            data_list=mock_directory_users_multiple_data_pages,
-            status_code=200,
+            list_function=self.directory_sync.list_users,
+            expected_all_page_data=mock_directory_users_multiple_data_pages,
         )
-
-        users = self.directory_sync.list_users()
-        all_users = []
-
-        for user in users.auto_paging_iter():
-            all_users.append(user)
-
-        assert len(list(all_users)) == len(mock_directory_users_multiple_data_pages)
-        assert (
-            list_data_to_dicts(all_users)
-        ) == mock_directory_users_multiple_data_pages
 
     def test_directory_user_groups_auto_pagination(
-        self,
-        mock_directory_groups_multiple_data_pages,
-        mock_pagination_request_for_http_client,
+        self, mock_directory_groups_multiple_data_pages, test_sync_auto_pagination
     ):
-        mock_pagination_request_for_http_client(
+        test_sync_auto_pagination(
             http_client=self.http_client,
-            data_list=mock_directory_groups_multiple_data_pages,
-            status_code=200,
-        )
-
-        groups = self.directory_sync.list_groups()
-        all_groups = []
-
-        for group in groups.auto_paging_iter():
-            all_groups.append(group)
-
-        assert len(list(all_groups)) == len(mock_directory_groups_multiple_data_pages)
-        assert (
-            list_data_to_dicts(all_groups)
-        ) == mock_directory_groups_multiple_data_pages
-
-    def test_auto_pagination_honors_limit(
-        self,
-        mock_directories_multiple_data_pages,
-        mock_pagination_request_for_http_client,
-    ):
-        # TODO: This does not actually test anything about the limit.
-        mock_pagination_request_for_http_client(
-            http_client=self.http_client,
-            data_list=mock_directories_multiple_data_pages,
-            status_code=200,
-        )
-
-        directories = self.directory_sync.list_directories()
-        all_directories = []
-
-        for directory in directories.auto_paging_iter():
-            all_directories.append(directory)
-
-        assert len(list(all_directories)) == len(mock_directories_multiple_data_pages)
-        assert (list_data_to_dicts(all_directories)) == api_directories_to_sdk(
-            mock_directories_multiple_data_pages
+            list_function=self.directory_sync.list_groups,
+            expected_all_page_data=mock_directory_groups_multiple_data_pages,
         )
 
 
@@ -499,7 +438,7 @@ class TestAsyncDirectorySync(DirectorySyncFixtures):
         directories = await self.directory_sync.list_directories()
         all_directories = []
 
-        async for directory in directories.auto_paging_iter():
+        async for directory in directories:
             all_directories.append(directory)
 
         assert len(list(all_directories)) == len(mock_directories_multiple_data_pages)
@@ -521,7 +460,7 @@ class TestAsyncDirectorySync(DirectorySyncFixtures):
         users = await self.directory_sync.list_users()
         all_users = []
 
-        async for user in users.auto_paging_iter():
+        async for user in users:
             all_users.append(user)
 
         assert len(list(all_users)) == len(mock_directory_users_multiple_data_pages)
@@ -543,33 +482,10 @@ class TestAsyncDirectorySync(DirectorySyncFixtures):
         groups = await self.directory_sync.list_groups()
         all_groups = []
 
-        async for group in groups.auto_paging_iter():
+        async for group in groups:
             all_groups.append(group)
 
         assert len(list(all_groups)) == len(mock_directory_groups_multiple_data_pages)
         assert (
             list_data_to_dicts(all_groups)
         ) == mock_directory_groups_multiple_data_pages
-
-    async def test_auto_pagination_honors_limit(
-        self,
-        mock_directories_multiple_data_pages,
-        mock_pagination_request_for_http_client,
-    ):
-        # TODO: This does not actually test anything about the limit.
-        mock_pagination_request_for_http_client(
-            http_client=self.http_client,
-            data_list=mock_directories_multiple_data_pages,
-            status_code=200,
-        )
-
-        directories = await self.directory_sync.list_directories()
-        all_directories = []
-
-        async for directory in directories.auto_paging_iter():
-            all_directories.append(directory)
-
-        assert len(list(all_directories)) == len(mock_directories_multiple_data_pages)
-        assert (list_data_to_dicts(all_directories)) == api_directories_to_sdk(
-            mock_directories_multiple_data_pages
-        )

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -181,7 +181,7 @@ class TestOrganizations(object):
         all_organizations = []
         organizations = self.organizations.list_organizations()
 
-        for org in organizations.auto_paging_iter():
+        for org in organizations:
             all_organizations.append(org)
 
         assert len(list(all_organizations)) == 10

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -323,7 +323,7 @@ class TestSSO(SSOFixtures):
         connections = self.sso.list_connections()
         all_connections = []
 
-        for connection in connections.auto_paging_iter():
+        for connection in connections:
             all_connections.append(connection)
 
         assert len(list(all_connections)) == len(mock_connections_multiple_data_pages)
@@ -448,7 +448,7 @@ class TestAsyncSSO(SSOFixtures):
         connections = await self.sso.list_connections()
         all_connections = []
 
-        async for connection in connections.auto_paging_iter():
+        async for connection in connections:
             all_connections.append(connection)
 
         assert len(list(all_connections)) == len(mock_connections_multiple_data_pages)

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -14,14 +14,7 @@ from workos.resources.directory_sync import (
     Directory,
     DirectoryUserWithGroups,
 )
-from workos.resources.list import (
-    ListArgs,
-    ListMetadata,
-    ListPage,
-    AsyncWorkOsListResource,
-    SyncOrAsyncListResource,
-    WorkOsListResource,
-)
+from workos.resources.list import ListArgs, ListMetadata, ListPage, WorkOsListResource
 
 
 class DirectoryListFilters(ListArgs, total=False):
@@ -43,6 +36,19 @@ class DirectoryGroupListFilters(ListArgs, total=False):
     directory: Optional[str]
 
 
+DirectoryUsersListResource = WorkOsListResource[
+    DirectoryUserWithGroups, DirectoryUserListFilters, ListMetadata
+]
+
+DirectoryGroupsListResource = WorkOsListResource[
+    DirectoryGroup, DirectoryGroupListFilters, ListMetadata
+]
+
+DirectoriesListResource = WorkOsListResource[
+    Directory, DirectoryListFilters, ListMetadata
+]
+
+
 class DirectorySyncModule(Protocol):
     def list_users(
         self,
@@ -52,7 +58,7 @@ class DirectorySyncModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> SyncOrAsync[DirectoryUsersListResource]: ...
 
     def list_groups(
         self,
@@ -62,7 +68,7 @@ class DirectorySyncModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> SyncOrAsync[DirectoryGroupsListResource]: ...
 
     def get_user(self, user: str) -> SyncOrAsync[DirectoryUserWithGroups]: ...
 
@@ -78,7 +84,7 @@ class DirectorySyncModule(Protocol):
         after: Optional[str] = None,
         organization_id: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> SyncOrAsync[DirectoriesListResource]: ...
 
     def delete_directory(self, directory: str) -> SyncOrAsync[None]: ...
 
@@ -100,9 +106,7 @@ class DirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[
-        DirectoryUserWithGroups, DirectoryUserListFilters, ListMetadata
-    ]:
+    ) -> DirectoryUsersListResource:
         """Gets a list of provisioned Users for a Directory.
 
         Note, either 'directory' or 'group' must be provided.
@@ -152,7 +156,7 @@ class DirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[DirectoryGroup, DirectoryGroupListFilters, ListMetadata]:
+    ) -> DirectoryGroupsListResource:
         """Gets a list of provisioned Groups for a Directory .
 
         Note, either 'directory_id' or 'user_id' must be provided.
@@ -255,7 +259,7 @@ class DirectorySync(DirectorySyncModule):
         after: Optional[str] = None,
         organization_id: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Directory, DirectoryListFilters, ListMetadata]:
+    ) -> DirectoriesListResource:
         """Gets details for existing Directories.
 
         Args:
@@ -324,9 +328,7 @@ class AsyncDirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[
-        DirectoryUserWithGroups, DirectoryUserListFilters, ListMetadata
-    ]:
+    ) -> DirectoryUsersListResource:
         """Gets a list of provisioned Users for a Directory.
 
         Note, either 'directory_id' or 'group_id' must be provided.
@@ -362,7 +364,7 @@ class AsyncDirectorySync(DirectorySyncModule):
             token=workos.api_key,
         )
 
-        return AsyncWorkOsListResource(
+        return WorkOsListResource(
             list_method=self.list_users,
             list_args=list_params,
             **ListPage[DirectoryUserWithGroups](**response).model_dump(),
@@ -376,9 +378,7 @@ class AsyncDirectorySync(DirectorySyncModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[
-        DirectoryGroup, DirectoryGroupListFilters, ListMetadata
-    ]:
+    ) -> DirectoryGroupsListResource:
         """Gets a list of provisioned Groups for a Directory .
 
         Note, either 'directory_id' or 'user_id' must be provided.
@@ -412,7 +412,7 @@ class AsyncDirectorySync(DirectorySyncModule):
             token=workos.api_key,
         )
 
-        return AsyncWorkOsListResource[
+        return WorkOsListResource[
             DirectoryGroup, DirectoryGroupListFilters, ListMetadata
         ](
             list_method=self.list_groups,
@@ -480,7 +480,7 @@ class AsyncDirectorySync(DirectorySyncModule):
         after: Optional[str] = None,
         organization_id: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[Directory, DirectoryListFilters, ListMetadata]:
+    ) -> DirectoriesListResource:
         """Gets details for existing Directories.
 
         Args:
@@ -511,7 +511,7 @@ class AsyncDirectorySync(DirectorySyncModule):
             params=list_params,
             token=workos.api_key,
         )
-        return AsyncWorkOsListResource[Directory, DirectoryListFilters, ListMetadata](
+        return WorkOsListResource[Directory, DirectoryListFilters, ListMetadata](
             list_method=self.list_directories,
             list_args=list_params,
             **ListPage[Directory](**response).model_dump(),

--- a/workos/events.py
+++ b/workos/events.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Protocol, Sequence, Union
+from typing import Optional, Protocol, Sequence
 
 import workos
 from workos.typing.sync_or_async import SyncOrAsync
@@ -8,7 +8,6 @@ from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
 from workos.utils.validation import EVENTS_MODULE, validate_settings
 from workos.resources.list import (
     ListAfterMetadata,
-    AsyncWorkOsListResource,
     ListArgs,
     ListPage,
     WorkOsListResource,
@@ -22,10 +21,7 @@ class EventsListFilters(ListArgs, total=False):
     range_end: Optional[str]
 
 
-EventsListResource = Union[
-    AsyncWorkOsListResource[Event, EventsListFilters, ListAfterMetadata],
-    WorkOsListResource[Event, EventsListFilters, ListAfterMetadata],
-]
+EventsListResource = WorkOsListResource[Event, EventsListFilters, ListAfterMetadata]
 
 
 class EventsModule(Protocol):
@@ -141,7 +137,7 @@ class AsyncEvents(EventsModule):
             token=workos.api_key,
         )
 
-        return AsyncWorkOsListResource[Event, EventsListFilters, ListAfterMetadata](
+        return WorkOsListResource[Event, EventsListFilters, ListAfterMetadata](
             list_method=self.list_events,
             list_args=params,
             **ListPage[Event](**response).model_dump(exclude_unset=True),

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -28,6 +28,11 @@ class OrganizationListFilters(ListArgs, total=False):
     domains: Optional[Sequence[str]]
 
 
+OrganizationsListResource = WorkOsListResource[
+    Organization, OrganizationListFilters, ListMetadata
+]
+
+
 class OrganizationsModule(Protocol):
     def list_organizations(
         self,
@@ -36,7 +41,7 @@ class OrganizationsModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Organization, OrganizationListFilters, ListMetadata]: ...
+    ) -> OrganizationsListResource: ...
 
     def get_organization(self, organization_id: str) -> Organization: ...
 
@@ -74,7 +79,7 @@ class Organizations(OrganizationsModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[Organization, OrganizationListFilters, ListMetadata]:
+    ) -> OrganizationsListResource:
         """Retrieve a list of organizations that have connections configured within your WorkOS dashboard.
 
         Kwargs:

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -19,11 +19,9 @@ from workos.utils.request_helper import (
 )
 from workos.utils.validation import SSO_MODULE, validate_settings
 from workos.resources.list import (
-    AsyncWorkOsListResource,
     ListArgs,
     ListMetadata,
     ListPage,
-    SyncOrAsyncListResource,
     WorkOsListResource,
 )
 
@@ -45,6 +43,11 @@ class ConnectionsListFilters(ListArgs, total=False):
     connection_type: Optional[ConnectionType]
     domain: Optional[str]
     organization_id: Optional[str]
+
+
+ConnectionsListResource = WorkOsListResource[
+    ConnectionWithDomains, ConnectionsListFilters, ListMetadata
+]
 
 
 class SSOModule(Protocol):
@@ -121,7 +124,7 @@ class SSOModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> SyncOrAsync[ConnectionsListResource]: ...
 
     def delete_connection(self, connection: str) -> SyncOrAsync[None]: ...
 
@@ -202,9 +205,7 @@ class SSO(SSOModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> WorkOsListResource[
-        ConnectionWithDomains, ConnectionsListFilters, ListMetadata
-    ]:
+    ) -> ConnectionsListResource:
         """Gets details for existing Connections.
 
         Args:
@@ -333,9 +334,7 @@ class AsyncSSO(SSOModule):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> AsyncWorkOsListResource[
-        ConnectionWithDomains, ConnectionsListFilters, ListMetadata
-    ]:
+    ) -> ConnectionsListResource:
         """Gets details for existing Connections.
 
         Args:
@@ -367,7 +366,7 @@ class AsyncSSO(SSOModule):
             token=workos.api_key,
         )
 
-        return AsyncWorkOsListResource[
+        return WorkOsListResource[
             ConnectionWithDomains, ConnectionsListFilters, ListMetadata
         ](
             list_method=self.list_connections,

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -5,7 +5,6 @@ from workos.resources.list import (
     ListArgs,
     ListMetadata,
     ListPage,
-    SyncOrAsyncListResource,
     WorkOsListResource,
 )
 from workos.resources.mfa import (
@@ -106,7 +105,7 @@ class UserManagementModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> WorkOsListResource[User, UsersListFilters, ListMetadata]: ...
 
     def create_user(
         self,
@@ -153,7 +152,9 @@ class UserManagementModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> WorkOsListResource[
+        OrganizationMembership, OrganizationMembershipsListFilters, ListMetadata
+    ]: ...
 
     def delete_organization_membership(
         self, organization_membership_id: str
@@ -354,7 +355,9 @@ class UserManagementModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> WorkOsListResource[
+        AuthenticationFactor, AuthenticationFactorsListFilters, ListMetadata
+    ]: ...
 
     def get_invitation(self, invitation_id: str) -> Invitation: ...
 
@@ -368,7 +371,7 @@ class UserManagementModule(Protocol):
         before: Optional[str] = None,
         after: Optional[str] = None,
         order: PaginationOrder = "desc",
-    ) -> SyncOrAsyncListResource: ...
+    ) -> WorkOsListResource[Invitation, InvitationsListFilters, ListMetadata]: ...
 
     def send_invitation(
         self,


### PR DESCRIPTION
## Description
Remove need to call `auto_paging_iter` and use single WorkOsListResource for sync and async.

With this change, list() methods can be used in two ways:
```
organization_memberships = (
    workos.client.user_management.list_organization_memberships(
        organization_id="org_01HB6C9FZWRPDTVQ3YNBB1Q3JB"
    )
)
```
OR
```
all_organization_memberships = []
for (
    organization_membership
) in workos.client.user_management.list_organization_memberships(
    organization_id="org_01HB6C9FZWRPDTVQ3YNBB1Q3JB",
):
    all_organization_memberships.append(organization_membership)
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.