### PR TITLE
Change unlinked directory state to inactive and convert in validator

### DIFF
--- a/tests/types/test_directory_state.py
+++ b/tests/types/test_directory_state.py
@@ -21,25 +21,14 @@ class TestDirectoryState:
         assert directory_state_type_adapter.validate_python("unlinked") == "inactive"
         assert directory_state_type_adapter.validate_python("inactive") == "inactive"
 
+    @pytest.mark.parametrize(
+        "type_value", ["foo", None, 5, {"definitely": "not a state"}]
+    )
     def test_invalid_values_returns_validation_error(
-        self, directory_state_type_adapter
+        self, directory_state_type_adapter, type_value
     ):
         try:
-            directory_state_type_adapter.validate_python("foo")
-        except ValidationError as e:
-            assert e.errors()[0]["type"] == "literal_error"
-
-        try:
-            directory_state_type_adapter.validate_python(None)
-        except ValidationError as e:
-            assert e.errors()[0]["type"] == "literal_error"
-
-        try:
-            directory_state_type_adapter.validate_python(5)
-        except ValidationError as e:
-            assert e.errors()[0]["type"] == "literal_error"
-
-        try:
-            directory_state_type_adapter.validate_python({"definitely": "not a state"})
+            directory_state_type_adapter.validate_python(type_value)
+            pytest.fail(f"Expected ValidationError for: {type_value}")
         except ValidationError as e:
             assert e.errors()[0]["type"] == "literal_error"

--- a/tests/types/test_directory_state.py
+++ b/tests/types/test_directory_state.py
@@ -1,0 +1,45 @@
+from math import e
+import pytest
+from pydantic import TypeAdapter, ValidationError
+from workos.types.directory_sync.directory_state import DirectoryState
+
+
+class TestDirectoryState:
+    @pytest.fixture
+    def directory_state_type_adapter(self):
+        return TypeAdapter(DirectoryState)
+
+    def test_convert_linked_to_active(self, directory_state_type_adapter):
+        assert directory_state_type_adapter.validate_python("active") == "active"
+        assert directory_state_type_adapter.validate_python("linked") == "active"
+        try:
+            directory_state_type_adapter.validate_python("foo")
+        except ValidationError as e:
+            assert e.errors()[0]["type"] == "literal_error"
+
+    def test_convert_unlinked_to_inactive(self, directory_state_type_adapter):
+        assert directory_state_type_adapter.validate_python("unlinked") == "inactive"
+        assert directory_state_type_adapter.validate_python("inactive") == "inactive"
+
+    def test_invalid_values_returns_validation_error(
+        self, directory_state_type_adapter
+    ):
+        try:
+            directory_state_type_adapter.validate_python("foo")
+        except ValidationError as e:
+            assert e.errors()[0]["type"] == "literal_error"
+
+        try:
+            directory_state_type_adapter.validate_python(None)
+        except ValidationError as e:
+            assert e.errors()[0]["type"] == "literal_error"
+
+        try:
+            directory_state_type_adapter.validate_python(5)
+        except ValidationError as e:
+            assert e.errors()[0]["type"] == "literal_error"
+
+        try:
+            directory_state_type_adapter.validate_python({"definitely": "not a state"})
+        except ValidationError as e:
+            assert e.errors()[0]["type"] == "literal_error"

--- a/tests/types/test_directory_state.py
+++ b/tests/types/test_directory_state.py
@@ -1,4 +1,3 @@
-from math import e
 import pytest
 from pydantic import TypeAdapter, ValidationError
 from workos.types.directory_sync.directory_state import DirectoryState

--- a/workos/types/directory_sync/directory_state.py
+++ b/workos/types/directory_sync/directory_state.py
@@ -5,21 +5,24 @@ from typing_extensions import Annotated
 
 ApiDirectoryState = Literal[
     "active",
-    "unlinked",
+    "inactive",
     "validating",
     "deleting",
     "invalid_credentials",
 ]
 
 
-def convert_linked_to_active(value: Any, info: ValidationInfo) -> Any:
-    if isinstance(value, str) and value == "linked":
-        return "active"
-    else:
-        return value
+def convert_legacy_directory_state(value: Any, info: ValidationInfo) -> Any:
+    if isinstance(value, str):
+        if value == "linked":
+            return "active"
+        elif value == "unlinked":
+            return "inactive"
+
+    return value
 
 
 DirectoryState = Annotated[
     ApiDirectoryState,
-    BeforeValidator(convert_linked_to_active),
+    BeforeValidator(convert_legacy_directory_state),
 ]


### PR DESCRIPTION
## Description
We made this conversion for `active` but forgot to do so for `inactive`

Resolves DSYNC-1785

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.