### PR TITLE
Require kwargs for multi param methods

### DIFF
--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -76,7 +76,9 @@ class TestAuditLogs:
             )
 
             response = self.audit_logs.create_event(
-                organization_id, event, "test_123456"
+                organization_id=organization_id,
+                event=event,
+                idempotency_key="test_123456",
             )
 
             assert request_kwargs["json"] == {
@@ -97,7 +99,9 @@ class TestAuditLogs:
             )
 
             response = self.audit_logs.create_event(
-                organization_id, mock_audit_log_event, idempotency_key
+                organization_id=organization_id,
+                event=mock_audit_log_event,
+                idempotency_key=idempotency_key,
             )
 
             assert request_kwargs["headers"]["idempotency-key"] == idempotency_key
@@ -116,7 +120,9 @@ class TestAuditLogs:
             )
 
             with pytest.raises(AuthenticationException) as excinfo:
-                self.audit_logs.create_event(organization_id, mock_audit_log_event)
+                self.audit_logs.create_event(
+                    organization_id=organization_id, event=mock_audit_log_event
+                )
             assert "(message=Unauthorized, request_id=a-request-id)" == str(
                 excinfo.value
             )
@@ -138,7 +144,9 @@ class TestAuditLogs:
             )
 
             with pytest.raises(BadRequestException) as excinfo:
-                self.audit_logs.create_event(organization_id, mock_audit_log_event)
+                self.audit_logs.create_event(
+                    organization_id=organization_id, event=mock_audit_log_event
+                )
                 assert excinfo.code == "invalid_audit_log"
                 assert excinfo.errors == ["error in a field"]
                 assert (
@@ -165,7 +173,9 @@ class TestAuditLogs:
             mock_http_client_with_response(self.http_client, expected_payload, 201)
 
             response = self.audit_logs.create_export(
-                organization_id, range_start, range_end
+                organization_id=organization_id,
+                range_start=range_start,
+                range_end=range_end,
             )
 
             assert response.dict() == expected_payload
@@ -216,7 +226,11 @@ class TestAuditLogs:
             )
 
             with pytest.raises(AuthenticationException) as excinfo:
-                self.audit_logs.create_export(organization_id, range_start, range_end)
+                self.audit_logs.create_export(
+                    organization_id=organization_id,
+                    range_start=range_start,
+                    range_end=range_end,
+                )
             assert "(message=Unauthorized, request_id=a-request-id)" == str(
                 excinfo.value
             )

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -134,7 +134,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             http_client=self.http_client, status_code=200, response_dict=mock_users
         )
 
-        users = self.directory_sync.list_users(group="directory_grp_id")
+        users = self.directory_sync.list_users(group_id="directory_grp_id")
 
         assert list_data_to_dicts(users.data) == mock_users["data"]
 

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -1,6 +1,5 @@
 from workos.mfa import Mfa
 import pytest
-
 from workos.utils.http_client import SyncHTTPClient
 
 
@@ -152,7 +151,7 @@ class TestMfa(object):
         mock_http_client_with_response(
             self.http_client, mock_enroll_factor_response_sms, 200
         )
-        enroll_factor = self.mfa.enroll_factor("sms", None, None, "9204448888")
+        enroll_factor = self.mfa.enroll_factor(type="sms", phone_number="9204448888")
         assert enroll_factor.dict() == mock_enroll_factor_response_sms
 
     def test_enroll_factor_totp_success(
@@ -162,7 +161,7 @@ class TestMfa(object):
             self.http_client, mock_enroll_factor_response_totp, 200
         )
         enroll_factor = self.mfa.enroll_factor(
-            "totp", totp_issuer="testissuer", totp_user="testuser"
+            type="totp", totp_issuer="testissuer", totp_user="testuser"
         )
         assert enroll_factor.dict() == mock_enroll_factor_response_totp
 
@@ -196,7 +195,7 @@ class TestMfa(object):
             self.http_client, mock_challenge_factor_response, 200
         )
         challenge_factor = self.mfa.challenge_factor(
-            "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM"
+            authentication_factor_id="auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM"
         )
         assert challenge_factor.dict() == mock_challenge_factor_response
 
@@ -207,6 +206,7 @@ class TestMfa(object):
             self.http_client, mock_verify_challenge_response, 200
         )
         verify_challenge = self.mfa.verify_challenge(
-            "auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT", "093647"
+            authentication_challenge_id="auth_challenge_01FXNXH8Y2K3YVWJ10P139A6DT",
+            code="093647",
         )
         assert verify_challenge.dict() == mock_verify_challenge_response

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -1,7 +1,5 @@
 import datetime
-
 import pytest
-
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from workos.organizations import Organizations
 from tests.utils.fixtures.mock_organization import MockOrganization

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -1,5 +1,4 @@
 import pytest
-
 from workos.passwordless import Passwordless
 from workos.utils.http_client import SyncHTTPClient
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -19,7 +19,9 @@ class TestPortal(object):
     def test_generate_link_sso(self, mock_portal_link, mock_http_client_with_response):
         mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
-        response = self.portal.generate_link("sso", "org_01EHQMYV6MBK39QC5PZXHY59C3")
+        response = self.portal.generate_link(
+            intent="sso", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
+        )
 
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
@@ -28,7 +30,9 @@ class TestPortal(object):
     ):
         mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
-        response = self.portal.generate_link("dsync", "org_01EHQMYV6MBK39QC5PZXHY59C3")
+        response = self.portal.generate_link(
+            intent="dsync", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
+        )
 
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
@@ -38,7 +42,7 @@ class TestPortal(object):
         mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link(
-            "audit_logs", "org_01EHQMYV6MBK39QC5PZXHY59C3"
+            intent="audit_logs", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
         )
 
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"
@@ -49,7 +53,7 @@ class TestPortal(object):
         mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link(
-            "log_streams", "org_01EHQMYV6MBK39QC5PZXHY59C3"
+            intent="log_streams", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
         )
 
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -365,7 +365,7 @@ class TestUserManagement(UserManagementFixtures):
             "password": "password",
         }
         user = self.user_management.update_user(
-            "user_01H7ZGXFP5C6BBQY6Z7277ZCT0", **params
+            user_id="user_01H7ZGXFP5C6BBQY6Z7277ZCT0", **params
         )
 
         assert request_kwargs["url"].endswith("users/user_01H7ZGXFP5C6BBQY6Z7277ZCT0")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -66,14 +66,14 @@ class TestWebhooks(object):
         assert "Timestamp outside the tolerance zone" in str(err.value)
 
     def test_sig_hash_does_not_match_expected_sig_length(self, mock_sig_hash):
-        result = self.webhooks.constant_time_compare(
+        result = self.webhooks._constant_time_compare(
             mock_sig_hash,
             "df25b6efdd39d82e7b30e75ea19655b306860ad5cde3eeaeb6f1dfea029ea25",
         )
         assert result == False
 
     def test_sig_hash_does_not_match_expected_sig_value(self, mock_sig_hash):
-        result = self.webhooks.constant_time_compare(
+        result = self.webhooks._constant_time_compare(
             mock_sig_hash,
             "df25b6efdd39d82e7b30e75ea19655b306860ad5cde3eeaeb6f1dfea029ea252",
         )

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -47,10 +47,10 @@ class TestWebhooks(object):
     ):
         with pytest.raises(ValueError) as err:
             self.webhooks.verify_event(
-                mock_event_body.encode("utf-8"),
-                mock_header_no_timestamp,
-                mock_secret,
-                180,
+                payload=mock_event_body.encode("utf-8"),
+                event_signature=mock_header_no_timestamp,
+                secret=mock_secret,
+                tolerance=180,
             )
         assert "Unable to extract timestamp and signature hash from header" in str(
             err.value
@@ -61,7 +61,10 @@ class TestWebhooks(object):
     ):
         with pytest.raises(ValueError) as err:
             self.webhooks.verify_event(
-                mock_event_body.encode("utf-8"), mock_header, mock_secret, 0
+                payload=mock_event_body.encode("utf-8"),
+                event_signature=mock_header,
+                secret=mock_secret,
+                tolerance=0,
             )
         assert "Timestamp outside the tolerance zone" in str(err.value)
 
@@ -84,10 +87,10 @@ class TestWebhooks(object):
     ):
         try:
             webhook = self.webhooks.verify_event(
-                mock_event_body.encode("utf-8"),
-                mock_header,
-                mock_secret,
-                99999999999999,
+                payload=mock_event_body.encode("utf-8"),
+                event_signature=mock_header,
+                secret=mock_secret,
+                tolerance=99999999999999,
             )
             assert type(webhook).__name__ == "ConnectionActivatedWebhook"
         except BaseException:
@@ -100,10 +103,10 @@ class TestWebhooks(object):
     ):
         with pytest.raises(ValueError) as err:
             self.webhooks.verify_header(
-                mock_event_body.encode("utf-8"),
-                mock_header,
-                mock_bad_secret,
-                99999999999999,
+                event_body=mock_event_body.encode("utf-8"),
+                event_signature=mock_header,
+                secret=mock_bad_secret,
+                tolerance=99999999999999,
             )
         assert (
             "Signature hash does not match the expected signature hash for payload"
@@ -114,10 +117,10 @@ class TestWebhooks(object):
         self, mock_unknown_webhook_body, mock_unknown_webhook_header, mock_secret
     ):
         result = self.webhooks.verify_event(
-            mock_unknown_webhook_body.encode("utf-8"),
-            mock_unknown_webhook_header,
-            mock_secret,
-            99999999999999,
+            payload=mock_unknown_webhook_body.encode("utf-8"),
+            event_signature=mock_unknown_webhook_header,
+            secret=mock_secret,
+            tolerance=99999999999999,
         )
         assert type(result).__name__ == "UntypedWebhook"
         assert result.dict() == json.loads(mock_unknown_webhook_body)

--- a/workos/async_client.py
+++ b/workos/async_client.py
@@ -28,7 +28,7 @@ class AsyncClient(BaseClient):
     _user_management: AsyncUserManagement
     _webhooks: WebhooksModule
 
-    def __init__(self, base_url: str, version: str, timeout: int):
+    def __init__(self, *, base_url: str, version: str, timeout: int):
         self._http_client = AsyncHTTPClient(
             base_url=base_url, version=version, timeout=timeout
         )

--- a/workos/audit_logs.py
+++ b/workos/audit_logs.py
@@ -14,6 +14,7 @@ EXPORTS_PATH = "audit_logs/exports"
 class AuditLogsModule(Protocol):
     def create_event(
         self,
+        *,
         organization_id: str,
         event: AuditLogEvent,
         idempotency_key: Optional[str] = None,
@@ -21,6 +22,7 @@ class AuditLogsModule(Protocol):
 
     def create_export(
         self,
+        *,
         organization_id: str,
         range_start: str,
         range_end: str,
@@ -44,6 +46,7 @@ class AuditLogs(AuditLogsModule):
 
     def create_event(
         self,
+        *,
         organization_id: str,
         event: AuditLogEvent,
         idempotency_key: Optional[str] = None,
@@ -71,6 +74,7 @@ class AuditLogs(AuditLogsModule):
 
     def create_export(
         self,
+        *,
         organization_id: str,
         range_start: str,
         range_end: str,

--- a/workos/client.py
+++ b/workos/client.py
@@ -28,7 +28,7 @@ class SyncClient(BaseClient):
     _user_management: UserManagement
     _webhooks: Webhooks
 
-    def __init__(self, base_url: str, version: str, timeout: int):
+    def __init__(self, *, base_url: str, version: str, timeout: int):
         self._http_client = SyncHTTPClient(
             base_url=base_url, version=version, timeout=timeout
         )

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -21,7 +21,6 @@ from workos.types.directory_sync import (
     DirectoryUserWithGroups,
 )
 from workos.types.list_resource import (
-    ListArgs,
     ListMetadata,
     ListPage,
     WorkOsListResource,
@@ -43,8 +42,9 @@ DirectoriesListResource = WorkOsListResource[
 class DirectorySyncModule(Protocol):
     def list_users(
         self,
+        *,
         directory_id: Optional[str] = None,
-        group: Optional[str] = None,
+        group_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
         after: Optional[str] = None,
@@ -53,8 +53,9 @@ class DirectorySyncModule(Protocol):
 
     def list_groups(
         self,
+        *,
         directory_id: Optional[str] = None,
-        user: Optional[str] = None,
+        user_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
         after: Optional[str] = None,
@@ -69,6 +70,7 @@ class DirectorySyncModule(Protocol):
 
     def list_directories(
         self,
+        *,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -91,8 +93,9 @@ class DirectorySync(DirectorySyncModule):
 
     def list_users(
         self,
+        *,
         directory_id: Optional[str] = None,
-        group: Optional[str] = None,
+        group_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
         after: Optional[str] = None,
@@ -121,8 +124,8 @@ class DirectorySync(DirectorySyncModule):
             "order": order,
         }
 
-        if group is not None:
-            list_params["group"] = group
+        if group_id is not None:
+            list_params["group"] = group_id
         if directory_id is not None:
             list_params["directory"] = directory_id
 
@@ -141,6 +144,7 @@ class DirectorySync(DirectorySyncModule):
 
     def list_groups(
         self,
+        *,
         directory_id: Optional[str] = None,
         user_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -244,6 +248,7 @@ class DirectorySync(DirectorySyncModule):
 
     def list_directories(
         self,
+        *,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -313,6 +318,7 @@ class AsyncDirectorySync(DirectorySyncModule):
 
     async def list_users(
         self,
+        *,
         directory_id: Optional[str] = None,
         group_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -363,6 +369,7 @@ class AsyncDirectorySync(DirectorySyncModule):
 
     async def list_groups(
         self,
+        *,
         directory_id: Optional[str] = None,
         user_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -465,6 +472,7 @@ class AsyncDirectorySync(DirectorySyncModule):
 
     async def list_directories(
         self,
+        *,
         search: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,

--- a/workos/events.py
+++ b/workos/events.py
@@ -20,6 +20,7 @@ EventsListResource = WorkOsListResource[Event, EventsListFilters, ListAfterMetad
 class EventsModule(Protocol):
     def list_events(
         self,
+        *,
         events: Sequence[EventType],
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         organization_id: Optional[str] = None,
@@ -40,6 +41,7 @@ class Events(EventsModule):
 
     def list_events(
         self,
+        *,
         events: Sequence[EventType],
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         organization_id: Optional[str] = None,
@@ -94,6 +96,7 @@ class AsyncEvents(EventsModule):
 
     async def list_events(
         self,
+        *,
         events: Sequence[EventType],
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         organization_id: Optional[str] = None,

--- a/workos/mfa.py
+++ b/workos/mfa.py
@@ -25,6 +25,7 @@ from workos.types.mfa import (
 class MFAModule(Protocol):
     def enroll_factor(
         self,
+        *,
         type: EnrollAuthenticationFactorType,
         totp_issuer: Optional[str] = None,
         totp_user: Optional[str] = None,
@@ -36,11 +37,11 @@ class MFAModule(Protocol):
     def delete_factor(self, authentication_factor_id: str) -> None: ...
 
     def challenge_factor(
-        self, authentication_factor_id: str, sms_template: Optional[str] = None
+        self, *, authentication_factor_id: str, sms_template: Optional[str] = None
     ) -> AuthenticationChallenge: ...
 
     def verify_challenge(
-        self, authentication_challenge_id: str, code: str
+        self, *, authentication_challenge_id: str, code: str
     ) -> AuthenticationChallengeVerificationResponse: ...
 
 
@@ -55,6 +56,7 @@ class Mfa(MFAModule):
 
     def enroll_factor(
         self,
+        *,
         type: EnrollAuthenticationFactorType,
         totp_issuer: Optional[str] = None,
         totp_user: Optional[str] = None,
@@ -146,6 +148,7 @@ class Mfa(MFAModule):
 
     def challenge_factor(
         self,
+        *,
         authentication_factor_id: str,
         sms_template: Optional[str] = None,
     ) -> AuthenticationChallenge:
@@ -175,7 +178,7 @@ class Mfa(MFAModule):
         return AuthenticationChallenge.model_validate(response)
 
     def verify_challenge(
-        self, authentication_challenge_id: str, code: str
+        self, *, authentication_challenge_id: str, code: str
     ) -> AuthenticationChallengeVerificationResponse:
         """
         Verifies the one time password provided by the end-user.

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -34,6 +34,7 @@ OrganizationsListResource = WorkOsListResource[
 class OrganizationsModule(Protocol):
     def list_organizations(
         self,
+        *,
         domains: Optional[Sequence[str]] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -47,6 +48,7 @@ class OrganizationsModule(Protocol):
 
     def create_organization(
         self,
+        *,
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         idempotency_key: Optional[str] = None,
@@ -54,6 +56,7 @@ class OrganizationsModule(Protocol):
 
     def update_organization(
         self,
+        *,
         organization_id: str,
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
@@ -72,6 +75,7 @@ class Organizations(OrganizationsModule):
 
     def list_organizations(
         self,
+        *,
         domains: Optional[Sequence[str]] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -144,6 +148,7 @@ class Organizations(OrganizationsModule):
 
     def create_organization(
         self,
+        *,
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         idempotency_key: Optional[str] = None,
@@ -171,6 +176,7 @@ class Organizations(OrganizationsModule):
 
     def update_organization(
         self,
+        *,
         organization_id: str,
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -1,5 +1,4 @@
-from typing import Literal, Optional, Protocol, Sequence
-from typing_extensions import TypedDict
+from typing import Optional, Protocol, Sequence
 import workos
 from workos.types.organizations.domain_data_input import DomainDataInput
 from workos.types.organizations.list_filters import OrganizationListFilters

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -10,6 +10,7 @@ from workos.utils.validation import Module, validate_settings
 class PasswordlessModule(Protocol):
     def create_session(
         self,
+        *,
         email: str,
         type: PasswordlessSessionType,
         redirect_uri: Optional[str] = None,
@@ -31,6 +32,7 @@ class Passwordless(PasswordlessModule):
 
     def create_session(
         self,
+        *,
         email: str,
         type: PasswordlessSessionType,
         redirect_uri: Optional[str] = None,

--- a/workos/portal.py
+++ b/workos/portal.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Protocol
+from typing import Optional, Protocol
 import workos
 from workos.types.portal.portal_link import PortalLink
 from workos.types.portal.portal_link_intent import PortalLinkIntent

--- a/workos/portal.py
+++ b/workos/portal.py
@@ -13,6 +13,7 @@ PORTAL_GENERATE_PATH = "portal/generate_link"
 class PortalModule(Protocol):
     def generate_link(
         self,
+        *,
         intent: PortalLinkIntent,
         organization_id: str,
         return_url: Optional[str] = None,
@@ -30,6 +31,7 @@ class Portal(PortalModule):
 
     def generate_link(
         self,
+        *,
         intent: PortalLinkIntent,
         organization_id: str,
         return_url: Optional[str] = None,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -50,6 +50,7 @@ class SSOModule(Protocol):
 
     def get_authorization_url(
         self,
+        *,
         redirect_uri: str,
         domain_hint: Optional[str] = None,
         login_hint: Optional[str] = None,
@@ -112,6 +113,7 @@ class SSOModule(Protocol):
 
     def list_connections(
         self,
+        *,
         connection_type: Optional[ConnectionType] = None,
         domain: Optional[str] = None,
         organization_id: Optional[str] = None,
@@ -193,6 +195,7 @@ class SSO(SSOModule):
 
     def list_connections(
         self,
+        *,
         connection_type: Optional[ConnectionType] = None,
         domain: Optional[str] = None,
         organization_id: Optional[str] = None,
@@ -322,6 +325,7 @@ class AsyncSSO(SSOModule):
 
     async def list_connections(
         self,
+        *,
         connection_type: Optional[ConnectionType] = None,
         domain: Optional[str] = None,
         organization_id: Optional[str] = None,

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -108,6 +108,7 @@ class UserManagementModule(Protocol):
 
     def list_users(
         self,
+        *,
         email: Optional[str] = None,
         organization_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -118,6 +119,7 @@ class UserManagementModule(Protocol):
 
     def create_user(
         self,
+        *,
         email: str,
         password: Optional[str] = None,
         password_hash: Optional[str] = None,
@@ -129,6 +131,7 @@ class UserManagementModule(Protocol):
 
     def update_user(
         self,
+        *,
         user_id: str,
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
@@ -141,11 +144,11 @@ class UserManagementModule(Protocol):
     def delete_user(self, user_id: str) -> SyncOrAsync[None]: ...
 
     def create_organization_membership(
-        self, user_id: str, organization_id: str, role_slug: Optional[str] = None
+        self, *, user_id: str, organization_id: str, role_slug: Optional[str] = None
     ) -> SyncOrAsync[OrganizationMembership]: ...
 
     def update_organization_membership(
-        self, organization_membership_id: str, role_slug: Optional[str] = None
+        self, *, organization_membership_id: str, role_slug: Optional[str] = None
     ) -> SyncOrAsync[OrganizationMembership]: ...
 
     def get_organization_membership(
@@ -154,6 +157,7 @@ class UserManagementModule(Protocol):
 
     def list_organization_memberships(
         self,
+        *,
         user_id: Optional[str] = None,
         organization_id: Optional[str] = None,
         statuses: Optional[Set[OrganizationMembershipStatus]] = None,
@@ -177,6 +181,7 @@ class UserManagementModule(Protocol):
 
     def get_authorization_url(
         self,
+        *,
         redirect_uri: str,
         domain_hint: Optional[str] = None,
         login_hint: Optional[str] = None,
@@ -248,6 +253,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_password(
         self,
+        *,
         email: str,
         password: str,
         ip_address: Optional[str] = None,
@@ -256,6 +262,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_code(
         self,
+        *,
         code: str,
         code_verifier: Optional[str] = None,
         ip_address: Optional[str] = None,
@@ -264,6 +271,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_magic_auth(
         self,
+        *,
         code: str,
         email: str,
         link_authorization_code: Optional[str] = None,
@@ -273,6 +281,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_email_verification(
         self,
+        *,
         code: str,
         pending_authentication_token: str,
         ip_address: Optional[str] = None,
@@ -281,6 +290,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_totp(
         self,
+        *,
         code: str,
         authentication_challenge_id: str,
         pending_authentication_token: str,
@@ -290,6 +300,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_organization_selection(
         self,
+        *,
         organization_id: str,
         pending_authentication_token: str,
         ip_address: Optional[str] = None,
@@ -298,6 +309,7 @@ class UserManagementModule(Protocol):
 
     def authenticate_with_refresh_token(
         self,
+        *,
         refresh_token: str,
         organization_id: Optional[str] = None,
         ip_address: Optional[str] = None,
@@ -334,7 +346,7 @@ class UserManagementModule(Protocol):
 
     def create_password_reset(self, email: str) -> SyncOrAsync[PasswordReset]: ...
 
-    def reset_password(self, token: str, new_password: str) -> SyncOrAsync[User]: ...
+    def reset_password(self, *, token: str, new_password: str) -> SyncOrAsync[User]: ...
 
     def get_email_verification(
         self, email_verification_id: str
@@ -342,16 +354,17 @@ class UserManagementModule(Protocol):
 
     def send_verification_email(self, user_id: str) -> SyncOrAsync[User]: ...
 
-    def verify_email(self, user_id: str, code: str) -> SyncOrAsync[User]: ...
+    def verify_email(self, *, user_id: str, code: str) -> SyncOrAsync[User]: ...
 
     def get_magic_auth(self, magic_auth_id: str) -> SyncOrAsync[MagicAuth]: ...
 
     def create_magic_auth(
-        self, email: str, invitation_token: Optional[str] = None
+        self, *, email: str, invitation_token: Optional[str] = None
     ) -> SyncOrAsync[MagicAuth]: ...
 
     def enroll_auth_factor(
         self,
+        *,
         user_id: str,
         type: AuthenticationFactorType,
         totp_issuer: Optional[str] = None,
@@ -361,6 +374,7 @@ class UserManagementModule(Protocol):
 
     def list_auth_factors(
         self,
+        *,
         user_id: str,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -376,6 +390,7 @@ class UserManagementModule(Protocol):
 
     def list_invitations(
         self,
+        *,
         email: Optional[str] = None,
         organization_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -386,6 +401,7 @@ class UserManagementModule(Protocol):
 
     def send_invitation(
         self,
+        *,
         email: str,
         organization_id: Optional[str] = None,
         expires_in_days: Optional[int] = None,
@@ -423,6 +439,7 @@ class UserManagement(UserManagementModule):
 
     def list_users(
         self,
+        *,
         email: Optional[str] = None,
         organization_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -468,6 +485,7 @@ class UserManagement(UserManagementModule):
 
     def create_user(
         self,
+        *,
         email: str,
         password: Optional[str] = None,
         password_hash: Optional[str] = None,
@@ -511,6 +529,7 @@ class UserManagement(UserManagementModule):
 
     def update_user(
         self,
+        *,
         user_id: str,
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
@@ -564,7 +583,7 @@ class UserManagement(UserManagementModule):
         )
 
     def create_organization_membership(
-        self, user_id: str, organization_id: str, role_slug: Optional[str] = None
+        self, *, user_id: str, organization_id: str, role_slug: Optional[str] = None
     ) -> OrganizationMembership:
         """Create a new OrganizationMembership for the given Organization and User.
 
@@ -594,7 +613,7 @@ class UserManagement(UserManagementModule):
         return OrganizationMembership.model_validate(response)
 
     def update_organization_membership(
-        self, organization_membership_id: str, role_slug: Optional[str] = None
+        self, *, organization_membership_id: str, role_slug: Optional[str] = None
     ) -> OrganizationMembership:
         """Updates an OrganizationMembership for the given id.
 
@@ -641,6 +660,7 @@ class UserManagement(UserManagementModule):
 
     def list_organization_memberships(
         self,
+        *,
         user_id: Optional[str] = None,
         organization_id: Optional[str] = None,
         statuses: Optional[Set[OrganizationMembershipStatus]] = None,
@@ -754,6 +774,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_password(
         self,
+        *,
         email: str,
         password: str,
         ip_address: Optional[str] = None,
@@ -783,6 +804,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_code(
         self,
+        *,
         code: str,
         code_verifier: Optional[str] = None,
         ip_address: Optional[str] = None,
@@ -815,6 +837,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_magic_auth(
         self,
+        *,
         code: str,
         email: str,
         link_authorization_code: Optional[str] = None,
@@ -847,6 +870,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_email_verification(
         self,
+        *,
         code: str,
         pending_authentication_token: str,
         ip_address: Optional[str] = None,
@@ -876,6 +900,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_totp(
         self,
+        *,
         code: str,
         authentication_challenge_id: str,
         pending_authentication_token: str,
@@ -908,6 +933,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_organization_selection(
         self,
+        *,
         organization_id: str,
         pending_authentication_token: str,
         ip_address: Optional[str] = None,
@@ -937,6 +963,7 @@ class UserManagement(UserManagementModule):
 
     def authenticate_with_refresh_token(
         self,
+        *,
         refresh_token: str,
         organization_id: Optional[str] = None,
         ip_address: Optional[str] = None,
@@ -1013,7 +1040,7 @@ class UserManagement(UserManagementModule):
 
         return PasswordReset.model_validate(response)
 
-    def reset_password(self, token: str, new_password: str) -> User:
+    def reset_password(self, *, token: str, new_password: str) -> User:
         """Resets user password using token that was sent to the user.
 
         Kwargs:
@@ -1074,7 +1101,7 @@ class UserManagement(UserManagementModule):
 
         return User.model_validate(response["user"])
 
-    def verify_email(self, user_id: str, code: str) -> User:
+    def verify_email(self, *, user_id: str, code: str) -> User:
         """Verifies user email using one-time code that was sent to the user.
 
         Kwargs:
@@ -1118,6 +1145,7 @@ class UserManagement(UserManagementModule):
 
     def create_magic_auth(
         self,
+        *,
         email: str,
         invitation_token: Optional[str] = None,
     ) -> MagicAuth:
@@ -1147,6 +1175,7 @@ class UserManagement(UserManagementModule):
 
     def enroll_auth_factor(
         self,
+        *,
         user_id: str,
         type: AuthenticationFactorType,
         totp_issuer: Optional[str] = None,
@@ -1183,6 +1212,7 @@ class UserManagement(UserManagementModule):
 
     def list_auth_factors(
         self,
+        *,
         user_id: str,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
         before: Optional[str] = None,
@@ -1265,6 +1295,7 @@ class UserManagement(UserManagementModule):
 
     def list_invitations(
         self,
+        *,
         email: Optional[str] = None,
         organization_id: Optional[str] = None,
         limit: int = DEFAULT_LIST_RESPONSE_LIMIT,
@@ -1310,6 +1341,7 @@ class UserManagement(UserManagementModule):
 
     def send_invitation(
         self,
+        *,
         email: str,
         organization_id: Optional[str] = None,
         expires_in_days: Optional[int] = None,

--- a/workos/webhooks.py
+++ b/workos/webhooks.py
@@ -14,7 +14,7 @@ class WebhooksModule(Protocol):
         self,
         *,
         payload: WebhookPayload,
-        sig_header: str,
+        event_signature: str,
         secret: str,
         tolerance: Optional[int] = None,
     ) -> Webhook: ...
@@ -46,14 +46,14 @@ class Webhooks(WebhooksModule):
         self,
         *,
         payload: WebhookPayload,
-        sig_header: str,
+        event_signature: str,
         secret: str,
         tolerance: Optional[int] = DEFAULT_TOLERANCE,
     ) -> Webhook:
         Webhooks.verify_header(
             self,
             event_body=payload,
-            event_signature=sig_header,
+            event_signature=event_signature,
             secret=secret,
             tolerance=tolerance,
         )


### PR DESCRIPTION
## Description
Switch multi-arg public SDK methods to keyword-only.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.