### PR TITLE
Fix type for authentication events

### DIFF
--- a/workos/types/events/authentication_payload.py
+++ b/workos/types/events/authentication_payload.py
@@ -42,7 +42,7 @@ class AuthenticationMfaSucceededPayload(AuthenticationResultSucceeded):
 
 
 class AuthenticationOauthSucceededPayload(AuthenticationResultSucceeded):
-    type: Literal["oath"]
+    type: Literal["oauth"]
     user_id: str
 
 

--- a/workos/types/events/authentication_payload.py
+++ b/workos/types/events/authentication_payload.py
@@ -6,7 +6,6 @@ class AuthenticationResultCommon(WorkOSModel):
     ip_address: Optional[str] = None
     user_agent: Optional[str] = None
     email: str
-    created_at: str
 
 
 class AuthenticationResultSucceeded(AuthenticationResultCommon):


### PR DESCRIPTION
## Description
The Authentication type had two bugs:
- It was always requiring `created_at` in the payload, which does not actually exist
- There was a typo in the oauth type

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.