### PR TITLE
Update mypy config to be more strict and properly check the entire wo…

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,11 @@
 [mypy]
-files=./workos/**/*.py
+packages = workos
+warn_return_any = True
+warn_unused_configs = True
+warn_unreachable = True
+warn_redundant_casts = True
+warn_no_return = True
+warn_unused_ignores = True
+implicit_reexport = False
+strict_equality = True
+strict = True


### PR DESCRIPTION
## Description
Our mypy config was wrong and didn't correctly check the entire module. This PR fixes that config and enables a few more strict flags.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.