### PR TITLE
Fga type updates

### DIFF
--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -8,11 +8,9 @@ from workos.exceptions import (
 )
 from workos.fga import FGA
 from workos.types.fga import (
-    CheckOperations,
     Subject,
-    WarrantCheck,
+    WarrantCheckInput,
     WarrantWrite,
-    WarrantWriteOperations,
 )
 
 
@@ -56,7 +54,7 @@ class TestValidation:
 
     def test_check_no_checks(self):
         with pytest.raises(ValueError):
-            self.fga.check(op=CheckOperations.ANY_OF.value, checks=[])
+            self.fga.check(op="any_of", checks=[])
 
 
 class TestErrorHandling:
@@ -334,7 +332,7 @@ class TestFGA:
         )
 
         response = self.fga.write_warrant(
-            op=WarrantWriteOperations.CREATE.value,
+            op="create",
             subject_type="role",
             subject_id="senior-accountant",
             subject_relation="member",
@@ -354,7 +352,7 @@ class TestFGA:
         response = self.fga.batch_write_warrants(
             batch=[
                 WarrantWrite(
-                    op=WarrantWriteOperations.CREATE.value,
+                    op="create",
                     resource_type="permission",
                     resource_id="view-balance-sheet",
                     relation="member",
@@ -365,7 +363,7 @@ class TestFGA:
                     ),
                 ),
                 WarrantWrite(
-                    op=WarrantWriteOperations.CREATE.value,
+                    op="create",
                     resource_type="permission",
                     resource_id="balance-sheet:edit",
                     relation="member",
@@ -388,9 +386,9 @@ class TestFGA:
         )
 
         response = self.fga.check(
-            op=CheckOperations.ANY_OF.value,
+            op="any_of",
             checks=[
-                WarrantCheck(
+                WarrantCheckInput(
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="viewer",
@@ -447,9 +445,9 @@ class TestFGA:
         )
 
         response = self.fga.check(
-            op=CheckOperations.ANY_OF.value,
+            op="any_of",
             checks=[
-                WarrantCheck(
+                WarrantCheckInput(
                     resource_type="report",
                     resource_id="report-a",
                     relation="editor",
@@ -475,13 +473,13 @@ class TestFGA:
 
         response = self.fga.check_batch(
             checks=[
-                WarrantCheck(
+                WarrantCheckInput(
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="viewer",
                     subject=Subject(resource_type="user", resource_id="user-A"),
                 ),
-                WarrantCheck(
+                WarrantCheckInput(
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="editor",

--- a/workos/fga.py
+++ b/workos/fga.py
@@ -5,12 +5,11 @@ from workos.types.fga import (
     Resource,
     ResourceType,
     Warrant,
-    WarrantCheck,
+    WarrantCheckInput,
     WarrantWrite,
     WarrantWriteOperation,
     WriteWarrantResponse,
     WarrantQueryResult,
-    CheckOperations,
 )
 from workos.types.fga.list_filters import (
     ResourceListFilters,
@@ -240,7 +239,7 @@ class FGAModule(Protocol):
     def check(
         self,
         *,
-        checks: Sequence[WarrantCheck],
+        checks: Sequence[WarrantCheckInput],
         op: Optional[CheckOperation] = None,
         debug: bool = False,
         warrant_token: Optional[str] = None,
@@ -261,7 +260,7 @@ class FGAModule(Protocol):
     def check_batch(
         self,
         *,
-        checks: Sequence[WarrantCheck],
+        checks: Sequence[WarrantCheckInput],
         debug: bool = False,
         warrant_token: Optional[str] = None,
     ) -> Sequence[CheckResponse]:
@@ -541,7 +540,7 @@ class FGA(FGAModule):
         response = self._http_client.request(
             "fga/v1/warrants",
             method=REQUEST_METHOD_POST,
-            json=[warrant.dict() for warrant in batch],
+            json=batch,
         )
 
         return WriteWarrantResponse.model_validate(response)
@@ -549,7 +548,7 @@ class FGA(FGAModule):
     def check(
         self,
         *,
-        checks: Sequence[WarrantCheck],
+        checks: Sequence[WarrantCheckInput],
         op: Optional[CheckOperation] = None,
         debug: bool = False,
         warrant_token: Optional[str] = None,
@@ -558,7 +557,7 @@ class FGA(FGAModule):
             raise ValueError("Incomplete arguments: No checks provided")
 
         body = {
-            "checks": [check.dict() for check in checks],
+            "checks": checks,
             "op": op,
             "debug": debug,
         }
@@ -575,7 +574,7 @@ class FGA(FGAModule):
     def check_batch(
         self,
         *,
-        checks: Sequence[WarrantCheck],
+        checks: Sequence[WarrantCheckInput],
         debug: bool = False,
         warrant_token: Optional[str] = None,
     ) -> Sequence[CheckResponse]:
@@ -583,8 +582,8 @@ class FGA(FGAModule):
             raise ValueError("Incomplete arguments: No checks provided")
 
         body = {
-            "checks": [check.dict() for check in checks],
-            "op": CheckOperations.BATCH.value,
+            "checks": checks,
+            "op": "batch",
             "debug": debug,
         }
 

--- a/workos/types/__init__.py
+++ b/workos/types/__init__.py
@@ -1,2 +1,4 @@
-from .audit_logs.audit_log_event import *
-from .organizations.domain_data_input import *
+from .audit_logs.audit_log_event import AuditLogEvent as AuditLogEvent
+from .organizations.domain_data_input import DomainDataInput as DomainDataInput
+from .fga.warrant import WarrantWrite as WarrantWrite
+from .fga.check import WarrantCheckInput as WarrantCheckInput

--- a/workos/types/fga/check.py
+++ b/workos/types/fga/check.py
@@ -1,18 +1,19 @@
-from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
 
 from workos.types.workos_model import WorkOSModel
 
 from .warrant import Subject
 
 
-class CheckOperations(Enum):
-    ANY_OF = "any_of"
-    ALL_OF = "all_of"
-    BATCH = "batch"
-
-
 CheckOperation = Literal["any_of", "all_of", "batch"]
+
+
+class WarrantCheckInput(TypedDict, total=False):
+    resource_type: str
+    resource_id: str
+    relation: str
+    subject: Subject
+    context: Optional[Mapping[str, Any]]
 
 
 class WarrantCheck(WorkOSModel):
@@ -20,25 +21,20 @@ class WarrantCheck(WorkOSModel):
     resource_id: str
     relation: str
     subject: Subject
-    context: Optional[Dict[str, Any]] = None
+    context: Optional[Mapping[str, Any]] = None
 
 
 class DecisionTreeNode(WorkOSModel):
     check: WarrantCheck
     decision: str
     processing_time: int
-    children: Optional[List["DecisionTreeNode"]] = None
+    children: Optional[Sequence["DecisionTreeNode"]] = None
     policy: Optional[str] = None
 
 
 class DebugInfo(WorkOSModel):
     processing_time: int
     decision_tree: DecisionTreeNode
-
-
-class CheckResults(Enum):
-    AUTHORIZED = "authorized"
-    NOT_AUTHORIZED = "not_authorized"
 
 
 CheckResult = Literal["authorized", "not_authorized"]
@@ -50,4 +46,4 @@ class CheckResponse(WorkOSModel):
     debug_info: Optional[DebugInfo] = None
 
     def authorized(self) -> bool:
-        return self.result == CheckResults.AUTHORIZED.value
+        return self.result == "authorized"

--- a/workos/types/fga/resource_types.py
+++ b/workos/types/fga/resource_types.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional
+from typing import Any, Mapping, Optional
 
 from workos.types.workos_model import WorkOSModel
 
 
 class ResourceType(WorkOSModel):
     type: str
-    relations: Dict[str, Any]
+    relations: Mapping[str, Any]
     created_at: Optional[str] = None

--- a/workos/types/fga/resources.py
+++ b/workos/types/fga/resources.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Mapping, Optional
 
 from workos.types.workos_model import WorkOSModel
 
@@ -6,5 +6,5 @@ from workos.types.workos_model import WorkOSModel
 class Resource(WorkOSModel):
     resource_type: str
     resource_id: str
-    meta: Optional[Dict[str, Any]] = None
+    meta: Optional[Mapping[str, Any]] = None
     created_at: Optional[str] = None

--- a/workos/types/fga/warrant.py
+++ b/workos/types/fga/warrant.py
@@ -1,5 +1,5 @@
-from enum import Enum
-from typing import Literal, Optional, Dict, Any
+from typing import Literal, Mapping, Optional, Any
+from typing_extensions import TypedDict
 
 from workos.types.workos_model import WorkOSModel
 
@@ -22,21 +22,16 @@ class WriteWarrantResponse(WorkOSModel):
     warrant_token: str
 
 
-class WarrantWriteOperations(Enum):
-    CREATE = "create"
-    DELETE = "delete"
-
-
 WarrantWriteOperation = Literal["create", "delete"]
 
 
-class WarrantWrite(WorkOSModel):
+class WarrantWrite(TypedDict, total=False):
     op: WarrantWriteOperation
     resource_type: str
     resource_id: str
     relation: str
     subject: Subject
-    policy: Optional[str] = None
+    policy: Optional[str]
 
 
 class WarrantQueryResult(WorkOSModel):
@@ -45,4 +40,4 @@ class WarrantQueryResult(WorkOSModel):
     relation: str
     warrant: Warrant
     is_implicit: bool
-    meta: Optional[Dict[str, Any]] = None
+    meta: Optional[Mapping[str, Any]] = None

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -1,5 +1,16 @@
 import platform
-from typing import Any, List, Mapping, cast, Dict, Generic, Optional, TypeVar, Union
+from typing import (
+    Any,
+    List,
+    Mapping,
+    Sequence,
+    cast,
+    Dict,
+    Generic,
+    Optional,
+    TypeVar,
+    Union,
+)
 from typing_extensions import NotRequired, TypedDict
 
 import httpx
@@ -23,7 +34,7 @@ DEFAULT_REQUEST_TIMEOUT = 25
 
 ParamsType = Optional[Mapping[str, Any]]
 HeadersType = Optional[Dict[str, str]]
-JsonType = Optional[Union[Mapping[str, Any], List[Any]]]
+JsonType = Optional[Union[Mapping[str, Any], Sequence[Any]]]
 ResponseJson = Mapping[Any, Any]
 
 

--- a/workos/utils/pagination_order.py
+++ b/workos/utils/pagination_order.py
@@ -1,10 +1,4 @@
-from enum import Enum
 from typing import Literal
-
-
-class Order(Enum):
-    Asc = "asc"
-    Desc = "desc"
 
 
 PaginationOrder = Literal["asc", "desc"]


### PR DESCRIPTION
## Description
Update FGA to match our conventions:
- Use duck types when possible
- Use `TypedDict` for complex input types
- Use string literals rather than enums
- Re-export input types from the `types` module for convenience

Stacked on #335

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.