### PR TITLE
Fix list_organization_memberships statuses parameter when auto paging

### DIFF
--- a/workos/types/user_management/list_filters.py
+++ b/workos/types/user_management/list_filters.py
@@ -1,5 +1,8 @@
-from typing import Optional
+from typing import Optional, Sequence
 from workos.types.list_resource import ListArgs
+from workos.types.user_management.organization_membership import (
+    OrganizationMembershipStatus,
+)
 
 
 class UsersListFilters(ListArgs, total=False):
@@ -15,8 +18,7 @@ class InvitationsListFilters(ListArgs, total=False):
 class OrganizationMembershipsListFilters(ListArgs, total=False):
     user_id: Optional[str]
     organization_id: Optional[str]
-    # A set of statuses that's concatenated into a comma-separated string
-    statuses: Optional[str]
+    statuses: Optional[Sequence[OrganizationMembershipStatus]]
 
 
 class AuthenticationFactorsListFilters(ListArgs, total=False):

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -947,7 +947,7 @@ class UserManagement(UserManagementModule):
         params: OrganizationMembershipsListFilters = {
             "user_id": user_id,
             "organization_id": organization_id,
-            "statuses": ",".join(statuses) if statuses else None,
+            "statuses": statuses,
             "limit": limit,
             "before": before,
             "after": after,
@@ -1521,7 +1521,7 @@ class AsyncUserManagement(UserManagementModule):
         params: OrganizationMembershipsListFilters = {
             "user_id": user_id,
             "organization_id": organization_id,
-            "statuses": ",".join(statuses) if statuses else None,
+            "statuses": statuses,
             "limit": limit,
             "before": before,
             "after": after,


### PR DESCRIPTION
## Description
Fix list_organization_memberships statuses parameter when auto paging.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.