### PR TITLE
Add certificate renewal intent

### DIFF
--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -78,3 +78,14 @@ class TestPortal(object):
             "organization": "org_01EHQMYV6MBK39QC5PZXHY59C3",
         }
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"
+
+    def test_generate_link_certificate_renewal(
+        self, mock_portal_link, mock_http_client_with_response
+    ):
+        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
+
+        response = self.portal.generate_link(
+            intent="certificate_renewal", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
+        )
+
+        assert response.link == "https://id.workos.com/portal/launch?secret=secret"

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -85,7 +85,8 @@ class TestPortal(object):
         mock_http_client_with_response(self.http_client, mock_portal_link, 201)
 
         response = self.portal.generate_link(
-            intent="certificate_renewal", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
+            intent="certificate_renewal",
+            organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3",
         )
 
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"

--- a/workos/types/portal/portal_link_intent.py
+++ b/workos/types/portal/portal_link_intent.py
@@ -1,4 +1,6 @@
 from typing import Literal
 
 
-PortalLinkIntent = Literal["audit_logs", "certificate_renewal", "dsync", "log_streams", "sso"]
+PortalLinkIntent = Literal[
+    "audit_logs", "certificate_renewal", "dsync", "log_streams", "sso"
+]

--- a/workos/types/portal/portal_link_intent.py
+++ b/workos/types/portal/portal_link_intent.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
 
-PortalLinkIntent = Literal["audit_logs", "dsync", "log_streams", "sso"]
+PortalLinkIntent = Literal["audit_logs", "certificate_renewal", "dsync", "log_streams", "sso"]


### PR DESCRIPTION
## Description
Adding the certificate renewal intent as an option for link generation

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.