### PR TITLE
Fix base_url parsing for build_url_with_query_params

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from tests.utils.client_configuration import ClientConfiguration
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from workos.types.list_resource import WorkOSListResource
+from workos.utils._base_http_client import DEFAULT_REQUEST_TIMEOUT
 from workos.utils.http_client import AsyncHTTPClient, HTTPClient, SyncHTTPClient
 
 
@@ -27,6 +29,44 @@ def async_http_client_for_test():
         client_id="client_b27needthisforssotemxo",
         version="test",
     )
+
+
+@pytest.fixture
+def sync_client_configuration_and_http_client_for_test():
+    base_url = "https://api.workos.test/"
+    client_id = "client_b27needthisforssotemxo"
+
+    client_configuration = ClientConfiguration(
+        base_url=base_url, client_id=client_id, request_timeout=DEFAULT_REQUEST_TIMEOUT
+    )
+
+    http_client = SyncHTTPClient(
+        api_key="sk_test",
+        base_url=base_url,
+        client_id=client_id,
+        version="test",
+    )
+
+    return client_configuration, http_client
+
+
+@pytest.fixture
+def async_client_configuration_and_http_client_for_test():
+    base_url = "https://api.workos.test/"
+    client_id = "client_b27needthisforssotemxo"
+
+    client_configuration = ClientConfiguration(
+        base_url=base_url, client_id=client_id, request_timeout=DEFAULT_REQUEST_TIMEOUT
+    )
+
+    http_client = AsyncHTTPClient(
+        api_key="sk_test",
+        base_url=base_url,
+        client_id=client_id,
+        version="test",
+    )
+
+    return client_configuration, http_client
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from tests.utils.client_configuration import ClientConfiguration
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from workos.types.list_resource import WorkOSListResource
 from workos.utils.http_client import AsyncHTTPClient, HTTPClient, SyncHTTPClient

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,7 +1,6 @@
 import json
 from six.moves.urllib.parse import parse_qsl, urlparse
 import pytest
-from tests.utils.client_configuration import client_configuration_for_http_client
 from tests.utils.fixtures.mock_profile import MockProfile
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from tests.utils.fixtures.mock_connection import MockConnection
@@ -50,13 +49,13 @@ class TestSSOBase(SSOFixtures):
     provider: SsoProviderType
 
     @pytest.fixture(autouse=True)
-    def setup(self, sync_http_client_for_test):
-        self.http_client = sync_http_client_for_test
+    def setup(self, sync_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            sync_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.sso = SSO(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                sync_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
         self.provider = "GoogleOAuth"
         self.customer_domain = "workos.com"
@@ -218,13 +217,13 @@ class TestSSO(SSOFixtures):
     provider: SsoProviderType
 
     @pytest.fixture(autouse=True)
-    def setup(self, sync_http_client_for_test):
-        self.http_client = sync_http_client_for_test
+    def setup(self, sync_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            sync_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.sso = SSO(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                sync_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
         self.provider = "GoogleOAuth"
         self.customer_domain = "workos.com"
@@ -342,13 +341,13 @@ class TestAsyncSSO(SSOFixtures):
     provider: SsoProviderType
 
     @pytest.fixture(autouse=True)
-    def setup(self, async_http_client_for_test):
-        self.http_client = async_http_client_for_test
+    def setup(self, async_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            async_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.sso = AsyncSSO(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                async_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
         self.provider = "GoogleOAuth"
         self.customer_domain = "workos.com"

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -11,9 +11,6 @@ from tests.utils.fixtures.mock_organization_membership import MockOrganizationMe
 from tests.utils.fixtures.mock_password_reset import MockPasswordReset
 from tests.utils.fixtures.mock_user import MockUser
 from tests.utils.list_resource import list_data_to_dicts, list_response_of
-from tests.utils.client_configuration import (
-    client_configuration_for_http_client,
-)
 from workos.user_management import AsyncUserManagement, UserManagement
 from workos.utils.request_helper import RESPONSE_TYPE_CODE
 
@@ -145,13 +142,13 @@ class UserManagementFixtures:
 
 class TestUserManagementBase(UserManagementFixtures):
     @pytest.fixture(autouse=True)
-    def setup(self, sync_http_client_for_test):
-        self.http_client = sync_http_client_for_test
+    def setup(self, sync_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            sync_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.user_management = UserManagement(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                sync_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
 
     def test_authorization_url_throws_value_error_with_missing_connection_organization_and_provider(
@@ -317,13 +314,13 @@ class TestUserManagementBase(UserManagementFixtures):
 
 class TestUserManagement(UserManagementFixtures):
     @pytest.fixture(autouse=True)
-    def setup(self, sync_http_client_for_test):
-        self.http_client = sync_http_client_for_test
+    def setup(self, sync_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            sync_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.user_management = UserManagement(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                sync_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
 
     def test_get_user(self, mock_user, capture_and_mock_http_client_request):
@@ -957,13 +954,13 @@ class TestUserManagement(UserManagementFixtures):
 @pytest.mark.asyncio
 class TestAsyncUserManagement(UserManagementFixtures):
     @pytest.fixture(autouse=True)
-    def setup(self, async_http_client_for_test):
-        self.http_client = async_http_client_for_test
+    def setup(self, async_client_configuration_and_http_client_for_test):
+        client_configuration, http_client = (
+            async_client_configuration_and_http_client_for_test
+        )
+        self.http_client = http_client
         self.user_management = AsyncUserManagement(
-            http_client=self.http_client,
-            client_configuration=client_configuration_for_http_client(
-                async_http_client_for_test
-            ),
+            http_client=self.http_client, client_configuration=client_configuration
         )
 
     async def test_get_user(self, mock_user, capture_and_mock_http_client_request):

--- a/tests/utils/client_configuration.py
+++ b/tests/utils/client_configuration.py
@@ -1,7 +1,6 @@
 from workos._client_configuration import (
     ClientConfiguration as ClientConfigurationProtocol,
 )
-from workos.utils._base_http_client import BaseHTTPClient
 
 
 class ClientConfiguration(ClientConfigurationProtocol):
@@ -21,13 +20,3 @@ class ClientConfiguration(ClientConfigurationProtocol):
     @property
     def request_timeout(self) -> int:
         return self._request_timeout
-
-
-def client_configuration_for_http_client(
-    http_client: BaseHTTPClient,
-) -> ClientConfiguration:
-    return ClientConfiguration(
-        base_url=http_client.base_url,
-        client_id=http_client.client_id,
-        request_timeout=http_client.timeout,
-    )

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -3,7 +3,7 @@ from workos._client_configuration import ClientConfiguration
 from workos.types.sso.connection import ConnectionType
 from workos.types.sso.sso_provider_type import SsoProviderType
 from workos.typing.sync_or_async import SyncOrAsync
-from workos.utils.http_client import AsyncHTTPClient, HTTPClient, SyncHTTPClient
+from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
 from workos.utils.pagination_order import PaginationOrder
 from workos.types.sso import ConnectionWithDomains, Profile, ProfileAndToken
 from workos.utils.request_helper import (

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -66,14 +66,13 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
         timeout: Optional[int] = DEFAULT_REQUEST_TIMEOUT,
     ) -> None:
         self._api_key = api_key
-        # Template for constructing the URL for an API request
-        self._base_url = "{}{{}}".format(base_url)
+        self._base_url = base_url
         self._client_id = client_id
         self._version = version
         self._timeout = DEFAULT_REQUEST_TIMEOUT if timeout is None else timeout
 
     def _generate_api_url(self, path: str) -> str:
-        return self._base_url.format(path)
+        return f"{self._base_url}{path}"
 
     def _build_headers(
         self,

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -1,7 +1,6 @@
 import platform
 from typing import (
     Any,
-    List,
     Mapping,
     Sequence,
     cast,

--- a/workos/utils/request_helper.py
+++ b/workos/utils/request_helper.py
@@ -24,4 +24,4 @@ class RequestHelper:
     def build_url_with_query_params(
         cls, base_url: str, path: str, **params: QueryParameterValue
     ) -> str:
-        return base_url.format(path) + "?" + urllib.parse.urlencode(params)
+        return base_url + path + "?" + urllib.parse.urlencode(params)


### PR DESCRIPTION
## Description
Fix base_url parsing for build_url_with_query_params. Tested against `get_authorization_url` for standalone and UM, but additionally `/organizations`, `/organization_memberships`, and `/events`.

Fixes #341.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.