### PR TITLE
Add missing LiteralOrUntyped wrappers

### DIFF
--- a/workos/types/audit_logs/audit_log_export.py
+++ b/workos/types/audit_logs/audit_log_export.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional
 
 from workos.types.workos_model import WorkOSModel
+from workos.typing.literals import LiteralOrUntyped
 
 
 AuditLogExportState = Literal["error", "pending", "ready"]
@@ -13,5 +14,5 @@ class AuditLogExport(WorkOSModel):
     id: str
     created_at: str
     updated_at: str
-    state: AuditLogExportState
+    state: LiteralOrUntyped[AuditLogExportState]
     url: Optional[str] = None

--- a/workos/types/fga/check.py
+++ b/workos/types/fga/check.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
 
 from workos.types.workos_model import WorkOSModel
+from workos.typing.literals import LiteralOrUntyped
 
 from .warrant import Subject
 
@@ -41,7 +42,7 @@ CheckResult = Literal["authorized", "not_authorized"]
 
 
 class CheckResponse(WorkOSModel):
-    result: CheckResult
+    result: LiteralOrUntyped[CheckResult]
     is_implicit: bool
     debug_info: Optional[DebugInfo] = None
 

--- a/workos/types/mfa/authentication_factor.py
+++ b/workos/types/mfa/authentication_factor.py
@@ -5,6 +5,7 @@ from workos.types.mfa.enroll_authentication_factor_type import (
     SmsAuthenticationFactorType,
     TotpAuthenticationFactorType,
 )
+from workos.typing.literals import LiteralOrUntyped
 
 
 AuthenticationFactorType = Literal[
@@ -38,7 +39,7 @@ class AuthenticationFactorBase(WorkOSModel):
     id: str
     created_at: str
     updated_at: str
-    type: AuthenticationFactorType
+    type: LiteralOrUntyped[AuthenticationFactorType]
     user_id: Optional[str] = None
 
 

--- a/workos/types/user_management/organization_membership.py
+++ b/workos/types/user_management/organization_membership.py
@@ -2,6 +2,7 @@ from typing import Literal
 from typing_extensions import TypedDict
 
 from workos.types.workos_model import WorkOSModel
+from workos.typing.literals import LiteralOrUntyped
 
 OrganizationMembershipStatus = Literal["active", "inactive", "pending"]
 
@@ -18,6 +19,6 @@ class OrganizationMembership(WorkOSModel):
     user_id: str
     organization_id: str
     role: OrganizationMembershipRole
-    status: OrganizationMembershipStatus
+    status: LiteralOrUntyped[OrganizationMembershipStatus]
     created_at: str
     updated_at: str


### PR DESCRIPTION
## Description
Make OrganizationMembership.status LiteralOrUntyped.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.