### PR TITLE
[BUG] Fix issue with Subject not serializing properly in FGA module

### DIFF
--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -8,9 +8,8 @@ from workos.exceptions import (
 )
 from workos.fga import FGA
 from workos.types.fga import (
-    Subject,
     WarrantCheckInput,
-    WarrantWrite,
+    WarrantWrite, SubjectInput,
 )
 
 
@@ -356,7 +355,7 @@ class TestFGA:
                     resource_type="permission",
                     resource_id="view-balance-sheet",
                     relation="member",
-                    subject=Subject(
+                    subject=SubjectInput(
                         resource_type="role",
                         resource_id="senior-accountant",
                         relation="member",
@@ -367,7 +366,7 @@ class TestFGA:
                     resource_type="permission",
                     resource_id="balance-sheet:edit",
                     relation="member",
-                    subject=Subject(
+                    subject=SubjectInput(
                         resource_type="user",
                         resource_id="user-b",
                     ),
@@ -392,7 +391,7 @@ class TestFGA:
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="viewer",
-                    subject=Subject(resource_type="user", resource_id="user-A"),
+                    subject=SubjectInput(resource_type="user", resource_id="user-A"),
                 )
             ],
         )
@@ -451,7 +450,7 @@ class TestFGA:
                     resource_type="report",
                     resource_id="report-a",
                     relation="editor",
-                    subject=Subject(resource_type="user", resource_id="user-b"),
+                    subject=SubjectInput(resource_type="user", resource_id="user-b"),
                     context={"tenant": "tenant-b"},
                 )
             ],
@@ -477,13 +476,13 @@ class TestFGA:
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="viewer",
-                    subject=Subject(resource_type="user", resource_id="user-A"),
+                    subject=SubjectInput(resource_type="user", resource_id="user-A"),
                 ),
                 WarrantCheckInput(
                     resource_type="schedule",
                     resource_id="schedule-A1",
                     relation="editor",
-                    subject=Subject(resource_type="user", resource_id="user-B"),
+                    subject=SubjectInput(resource_type="user", resource_id="user-B"),
                 ),
             ]
         )

--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -9,7 +9,8 @@ from workos.exceptions import (
 from workos.fga import FGA
 from workos.types.fga import (
     WarrantCheckInput,
-    WarrantWrite, SubjectInput,
+    WarrantWrite,
+    SubjectInput,
 )
 
 

--- a/workos/types/fga/check.py
+++ b/workos/types/fga/check.py
@@ -13,7 +13,7 @@ class WarrantCheckInput(TypedDict, total=False):
     resource_id: str
     relation: str
     subject: SubjectInput
-    context: Optional[Mapping[str, Any]] = None
+    context: Optional[Mapping[str, Any]]
 
 
 class WarrantCheck(WorkOSModel):

--- a/workos/types/fga/check.py
+++ b/workos/types/fga/check.py
@@ -3,8 +3,7 @@ from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
 from workos.types.workos_model import WorkOSModel
 from workos.typing.literals import LiteralOrUntyped
 
-from .warrant import Subject
-
+from .warrant import Subject, SubjectInput
 
 CheckOperation = Literal["any_of", "all_of", "batch"]
 
@@ -13,8 +12,8 @@ class WarrantCheckInput(TypedDict, total=False):
     resource_type: str
     resource_id: str
     relation: str
-    subject: Subject
-    context: Optional[Mapping[str, Any]]
+    subject: SubjectInput
+    context: Optional[Mapping[str, Any]] = None
 
 
 class WarrantCheck(WorkOSModel):

--- a/workos/types/fga/warrant.py
+++ b/workos/types/fga/warrant.py
@@ -4,6 +4,12 @@ from typing_extensions import TypedDict
 from workos.types.workos_model import WorkOSModel
 
 
+class SubjectInput(TypedDict, total=False):
+    resource_type: str
+    resource_id: str
+    relation: Optional[str]
+
+
 class Subject(WorkOSModel):
     resource_type: str
     resource_id: str
@@ -30,7 +36,7 @@ class WarrantWrite(TypedDict, total=False):
     resource_type: str
     resource_id: str
     relation: str
-    subject: Subject
+    subject: SubjectInput
     policy: Optional[str]
 
 


### PR DESCRIPTION
## Description
Fixes issue where `TypeError: Object of type Subject is not JSON serializable` would make `batch_write_warrants` and `check` methods unusable. 
