### PR TITLE
Add directory metadata

### DIFF
--- a/tests/utils/fixtures/mock_directory.py
+++ b/tests/utils/fixtures/mock_directory.py
@@ -1,10 +1,24 @@
 import datetime
 
-from workos.types.directory_sync import Directory
+from workos.types.directory_sync import (
+    Directory,
+    DirectoryMetadata,
+    DirectoryUsersMetadata,
+)
+
+
+class MockDirectoryUsersMetadata(DirectoryUsersMetadata):
+    def __init__(self, active=0, inactive=0):
+        super().__init__(active=active, inactive=inactive)
+
+
+class MockDirectoryMetadata(DirectoryMetadata):
+    def __init__(self, users, groups=0):
+        super().__init__(users=users, groups=groups)
 
 
 class MockDirectory(Directory):
-    def __init__(self, id):
+    def __init__(self, id, metadata=None):
         now = datetime.datetime.now().isoformat()
         super().__init__(
             object="directory",
@@ -15,6 +29,7 @@ class MockDirectory(Directory):
             name="Some fake name",
             state="active",
             type="gsuite directory",
+            metadata=metadata,
             created_at=now,
             updated_at=now,
         )

--- a/workos/types/directory_sync/directory.py
+++ b/workos/types/directory_sync/directory.py
@@ -5,6 +5,16 @@ from workos.types.directory_sync.directory_type import DirectoryType
 from workos.typing.literals import LiteralOrUntyped
 
 
+class DirectoryUsersMetadata(WorkOSModel):
+    active: int
+    inactive: int
+
+
+class DirectoryMetadata(WorkOSModel):
+    users: DirectoryUsersMetadata
+    groups: int
+
+
 class Directory(WorkOSModel):
     """Representation of a Directory Response as returned by WorkOS through the Directory Sync feature."""
 
@@ -16,5 +26,6 @@ class Directory(WorkOSModel):
     external_key: str
     state: LiteralOrUntyped[DirectoryState]
     type: LiteralOrUntyped[DirectoryType]
+    metadata: Optional[DirectoryMetadata] = None
     created_at: str
     updated_at: str


### PR DESCRIPTION
## Description

This changeset adds metadata onto Directories which provides insights on the count of active/inactive users and count of groups for a directory.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.