### PR TITLE
Use syncify for remaining async test suites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,20 +118,8 @@ def sync_http_client_for_test():
 
 
 @pytest.fixture
-def async_http_client_for_test():
-    _, _, http_client = _get_test_client_setup("AsyncHTTPClient")
-    return http_client
-
-
-@pytest.fixture
 def sync_client_configuration_and_http_client_for_test():
     _, client_configuration, http_client = _get_test_client_setup("SyncHTTPClient")
-    return client_configuration, http_client
-
-
-@pytest.fixture
-def async_client_configuration_and_http_client_for_test():
-    _, client_configuration, http_client = _get_test_client_setup("AsyncHTTPClient")
     return client_configuration, http_client
 
 

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -1,3 +1,4 @@
+from typing import Union
 import pytest
 
 from tests.types.test_auto_pagination_function import TestAutoPaginationFunction
@@ -5,6 +6,7 @@ from tests.utils.list_resource import list_data_to_dicts, list_response_of
 from tests.utils.fixtures.mock_directory import MockDirectory
 from tests.utils.fixtures.mock_directory_user import MockDirectoryUser
 from tests.utils.fixtures.mock_directory_group import MockDirectoryGroup
+from tests.utils.syncify import syncify
 from workos.directory_sync import AsyncDirectorySync, DirectorySync
 
 
@@ -22,7 +24,13 @@ def api_directories_to_sdk(directories):
     return list(map(lambda x: api_directory_to_sdk(x), directories))
 
 
-class DirectorySyncFixtures:
+@pytest.mark.sync_and_async(DirectorySync, AsyncDirectorySync)
+class TestDirectorySync:
+    @pytest.fixture(autouse=True)
+    def setup(self, module_instance: Union[DirectorySync, AsyncDirectorySync]):
+        self.http_client = module_instance._http_client
+        self.directory_sync = module_instance
+
     @pytest.fixture
     def mock_users(self):
         user_list = [MockDirectoryUser(id=str(i)).dict() for i in range(100)]
@@ -108,13 +116,6 @@ class DirectorySyncFixtures:
     def mock_directory(self):
         return MockDirectory("directory_id").dict()
 
-
-class TestDirectorySync(DirectorySyncFixtures):
-    @pytest.fixture(autouse=True)
-    def setup(self, sync_http_client_for_test):
-        self.http_client = sync_http_client_for_test
-        self.directory_sync = DirectorySync(http_client=self.http_client)
-
     def test_list_users_with_directory(
         self, mock_users, capture_and_mock_http_client_request
     ):
@@ -122,7 +123,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             http_client=self.http_client, status_code=200, response_dict=mock_users
         )
 
-        users = self.directory_sync.list_users(directory_id="directory_id")
+        users = syncify(self.directory_sync.list_users(directory_id="directory_id"))
 
         assert list_data_to_dicts(users.data) == mock_users["data"]
         assert request_kwargs["url"].endswith("/directory_users")
@@ -140,7 +141,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             http_client=self.http_client, status_code=200, response_dict=mock_users
         )
 
-        users = self.directory_sync.list_users(group_id="directory_grp_id")
+        users = syncify(self.directory_sync.list_users(group_id="directory_grp_id"))
 
         assert list_data_to_dicts(users.data) == mock_users["data"]
         assert request_kwargs["url"].endswith("/directory_users")
@@ -158,7 +159,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             http_client=self.http_client, status_code=200, response_dict=mock_groups
         )
 
-        groups = self.directory_sync.list_groups(directory_id="directory_id")
+        groups = syncify(self.directory_sync.list_groups(directory_id="directory_id"))
 
         assert list_data_to_dicts(groups.data) == mock_groups["data"]
         assert request_kwargs["url"].endswith("/directory_groups")
@@ -176,7 +177,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             http_client=self.http_client, status_code=200, response_dict=mock_groups
         )
 
-        groups = self.directory_sync.list_groups(user_id="directory_user_id")
+        groups = syncify(self.directory_sync.list_groups(user_id="directory_user_id"))
 
         assert list_data_to_dicts(groups.data) == mock_groups["data"]
         assert request_kwargs["url"].endswith("/directory_groups")
@@ -194,7 +195,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             response_dict=mock_user,
         )
 
-        user = self.directory_sync.get_user(user_id="directory_user_id")
+        user = syncify(self.directory_sync.get_user(user_id="directory_user_id"))
 
         assert user.dict() == mock_user
         assert request_kwargs["url"].endswith("/directory_users/directory_user_id")
@@ -207,8 +208,10 @@ class TestDirectorySync(DirectorySyncFixtures):
             response_dict=mock_group,
         )
 
-        group = self.directory_sync.get_group(
-            group_id="directory_group_01FHGRYAQ6ERZXXXXXX1E01QFE"
+        group = syncify(
+            self.directory_sync.get_group(
+                group_id="directory_group_01FHGRYAQ6ERZXXXXXX1E01QFE"
+            )
         )
 
         assert group.dict() == mock_group
@@ -226,7 +229,7 @@ class TestDirectorySync(DirectorySyncFixtures):
             response_dict=mock_directories,
         )
 
-        directories = self.directory_sync.list_directories()
+        directories = syncify(self.directory_sync.list_directories())
 
         assert list_data_to_dicts(directories.data) == api_directories_to_sdk(
             mock_directories["data"]
@@ -245,7 +248,9 @@ class TestDirectorySync(DirectorySyncFixtures):
             response_dict=mock_directory,
         )
 
-        directory = self.directory_sync.get_directory(directory_id="directory_id")
+        directory = syncify(
+            self.directory_sync.get_directory(directory_id="directory_id")
+        )
 
         assert directory.dict() == api_directory_to_sdk(mock_directory)
         assert request_kwargs["url"].endswith("/directories/directory_id")
@@ -258,7 +263,9 @@ class TestDirectorySync(DirectorySyncFixtures):
             headers={"content-type": "text/plain; charset=utf-8"},
         )
 
-        response = self.directory_sync.delete_directory(directory_id="directory_id")
+        response = syncify(
+            self.directory_sync.delete_directory(directory_id="directory_id")
+        )
 
         assert request_kwargs["url"].endswith("/directories/directory_id")
         assert request_kwargs["method"] == "delete"
@@ -272,8 +279,8 @@ class TestDirectorySync(DirectorySyncFixtures):
             status_code=200,
             response_dict=mock_user,
         )
-        mock_user_instance = self.directory_sync.get_user(
-            "directory_user_01E1JG7J09H96KYP8HM9B0G5SJ"
+        mock_user_instance = syncify(
+            self.directory_sync.get_user("directory_user_01E1JG7J09H96KYP8HM9B0G5SJ")
         )
         primary_email = mock_user_instance.primary_email()
         assert primary_email
@@ -287,8 +294,8 @@ class TestDirectorySync(DirectorySyncFixtures):
             status_code=200,
             response_dict=mock_user_no_email,
         )
-        mock_user_instance = self.directory_sync.get_user(
-            "directory_user_01E1JG7J09H96KYP8HM9B0G5SJ"
+        mock_user_instance = syncify(
+            self.directory_sync.get_user("directory_user_01E1JG7J09H96KYP8HM9B0G5SJ")
         )
 
         me = mock_user_instance.primary_email()
@@ -327,282 +334,3 @@ class TestDirectorySync(DirectorySyncFixtures):
             list_function=self.directory_sync.list_groups,
             expected_all_page_data=mock_directory_groups_multiple_data_pages,
         )
-
-
-@pytest.mark.asyncio
-class TestAsyncDirectorySync(DirectorySyncFixtures):
-    @pytest.fixture(autouse=True)
-    def setup(self, async_http_client_for_test):
-        self.http_client = async_http_client_for_test
-        self.directory_sync = AsyncDirectorySync(http_client=self.http_client)
-
-    async def test_list_users_with_directory(
-        self, mock_users, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client, status_code=200, response_dict=mock_users
-        )
-
-        users = await self.directory_sync.list_users(directory_id="directory_id")
-
-        assert list_data_to_dicts(users.data) == mock_users["data"]
-        assert request_kwargs["url"].endswith("/directory_users")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "directory": "directory_id",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_list_users_with_group(
-        self, mock_users, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client, status_code=200, response_dict=mock_users
-        )
-
-        users = await self.directory_sync.list_users(group_id="directory_grp_id")
-
-        assert list_data_to_dicts(users.data) == mock_users["data"]
-        assert request_kwargs["url"].endswith("/directory_users")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "group": "directory_grp_id",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_list_groups_with_directory(
-        self, mock_groups, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client, status_code=200, response_dict=mock_groups
-        )
-
-        groups = await self.directory_sync.list_groups(directory_id="directory_id")
-
-        assert list_data_to_dicts(groups.data) == mock_groups["data"]
-        assert request_kwargs["url"].endswith("/directory_groups")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "directory": "directory_id",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_list_groups_with_user(
-        self, mock_groups, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client, status_code=200, response_dict=mock_groups
-        )
-
-        groups = await self.directory_sync.list_groups(user_id="directory_user_id")
-
-        assert list_data_to_dicts(groups.data) == mock_groups["data"]
-        assert request_kwargs["url"].endswith("/directory_groups")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "user": "directory_user_id",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_get_user(self, mock_user, capture_and_mock_http_client_request):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_user,
-        )
-
-        user = await self.directory_sync.get_user(user_id="directory_user_id")
-
-        assert user.dict() == mock_user
-        assert request_kwargs["url"].endswith("/directory_users/directory_user_id")
-        assert request_kwargs["method"] == "get"
-
-    async def test_get_group(self, mock_group, capture_and_mock_http_client_request):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_group,
-        )
-
-        group = await self.directory_sync.get_group(
-            group_id="directory_group_01FHGRYAQ6ERZXXXXXX1E01QFE"
-        )
-
-        assert group.dict() == mock_group
-        assert request_kwargs["url"].endswith(
-            "/directory_groups/directory_group_01FHGRYAQ6ERZXXXXXX1E01QFE"
-        )
-        assert request_kwargs["method"] == "get"
-
-    async def test_list_directories(
-        self, mock_directories, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_directories,
-        )
-
-        directories = await self.directory_sync.list_directories()
-
-        assert list_data_to_dicts(directories.data) == api_directories_to_sdk(
-            mock_directories["data"]
-        )
-        assert request_kwargs["url"].endswith("/directories")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_get_directory(
-        self, mock_directory, capture_and_mock_http_client_request
-    ):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_directory,
-        )
-
-        directory = await self.directory_sync.get_directory(directory_id="directory_id")
-
-        assert directory.dict() == api_directory_to_sdk(mock_directory)
-        assert request_kwargs["url"].endswith("/directories/directory_id")
-        assert request_kwargs["method"] == "get"
-
-    async def test_delete_directory(self, capture_and_mock_http_client_request):
-        request_kwargs = capture_and_mock_http_client_request(
-            http_client=self.http_client,
-            status_code=202,
-            headers={"content-type": "text/plain; charset=utf-8"},
-        )
-
-        response = await self.directory_sync.delete_directory(
-            directory_id="directory_id"
-        )
-
-        assert request_kwargs["url"].endswith("/directories/directory_id")
-        assert request_kwargs["method"] == "delete"
-        assert response is None
-
-    async def test_primary_email(
-        self, mock_user, mock_user_primary_email, mock_http_client_with_response
-    ):
-        mock_http_client_with_response(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_user,
-        )
-        mock_user_instance = await self.directory_sync.get_user(
-            "directory_user_01E1JG7J09H96KYP8HM9B0G5SJ"
-        )
-        primary_email = mock_user_instance.primary_email()
-        assert primary_email
-        assert primary_email.dict() == mock_user_primary_email
-
-    async def test_primary_email_none(
-        self, mock_user_no_email, mock_http_client_with_response
-    ):
-        mock_http_client_with_response(
-            http_client=self.http_client,
-            status_code=200,
-            response_dict=mock_user_no_email,
-        )
-        mock_user_instance = await self.directory_sync.get_user(
-            "directory_user_01E1JG7J09H96KYP8HM9B0G5SJ"
-        )
-
-        me = mock_user_instance.primary_email()
-
-        assert me == None
-
-    async def test_list_directories_auto_pagination(
-        self,
-        mock_directories_multiple_data_pages,
-        capture_and_mock_pagination_request_for_http_client,
-    ):
-        request_kwargs = capture_and_mock_pagination_request_for_http_client(
-            http_client=self.http_client,
-            data_list=mock_directories_multiple_data_pages,
-            status_code=200,
-        )
-
-        directories = await self.directory_sync.list_directories()
-        all_directories = []
-
-        async for directory in directories:
-            all_directories.append(directory)
-
-        assert len(list(all_directories)) == len(mock_directories_multiple_data_pages)
-        assert (list_data_to_dicts(all_directories)) == api_directories_to_sdk(
-            mock_directories_multiple_data_pages
-        )
-        assert request_kwargs["url"].endswith("/directories")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "after": "dir_39",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_directory_users_auto_pagination(
-        self,
-        mock_directory_users_multiple_data_pages,
-        capture_and_mock_pagination_request_for_http_client,
-    ):
-        request_kwargs = capture_and_mock_pagination_request_for_http_client(
-            http_client=self.http_client,
-            data_list=mock_directory_users_multiple_data_pages,
-            status_code=200,
-        )
-
-        users = await self.directory_sync.list_users()
-        all_users = []
-
-        async for user in users:
-            all_users.append(user)
-
-        assert len(list(all_users)) == len(mock_directory_users_multiple_data_pages)
-        assert (
-            list_data_to_dicts(all_users)
-        ) == mock_directory_users_multiple_data_pages
-        assert request_kwargs["url"].endswith("/directory_users")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "after": "directory_user_39",
-            "limit": 10,
-            "order": "desc",
-        }
-
-    async def test_directory_user_groups_auto_pagination(
-        self,
-        mock_directory_groups_multiple_data_pages,
-        capture_and_mock_pagination_request_for_http_client,
-    ):
-        request_kwargs = capture_and_mock_pagination_request_for_http_client(
-            http_client=self.http_client,
-            data_list=mock_directory_groups_multiple_data_pages,
-            status_code=200,
-        )
-
-        groups = await self.directory_sync.list_groups()
-        all_groups = []
-
-        async for group in groups:
-            all_groups.append(group)
-
-        assert len(list(all_groups)) == len(mock_directory_groups_multiple_data_pages)
-        assert (
-            list_data_to_dicts(all_groups)
-        ) == mock_directory_groups_multiple_data_pages
-        assert request_kwargs["url"].endswith("/directory_groups")
-        assert request_kwargs["method"] == "get"
-        assert request_kwargs["params"] == {
-            "after": "directory_group_39",
-            "limit": 10,
-            "order": "desc",
-        }


### PR DESCRIPTION
## Description
Use syncify for remaining async test suites.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.