### PR TITLE
Fix authentication error payload

### DIFF
--- a/tests/test_async_http_client.py
+++ b/tests/test_async_http_client.py
@@ -227,7 +227,7 @@ class TestAsyncHTTPClient(object):
         try:
             await self.http_client.request("bad_place")
         except BadRequestException as ex:
-            assert str(ex) == "(message=No message, request_id=request-123)"
+            assert str(ex) == "(message=No message, request_id=request-123, foo=bar)"
         except Exception as ex:
             assert ex.__class__ == BadRequestException
 

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -204,7 +204,7 @@ class TestSyncHTTPClient(object):
             # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == expected_exception
 
-    def test_bad_request_exceptions_include_expected_request_data(self):
+    def test_bad_request_exceptions_include_request_data(self):
         request_id = "request-123"
         error = "example_error"
         error_description = "Example error description"
@@ -212,7 +212,7 @@ class TestSyncHTTPClient(object):
         self.http_client._client.request = MagicMock(
             return_value=httpx.Response(
                 status_code=400,
-                json={"error": error, "error_description": error_description},
+                json={"error": error, "error_description": error_description, "foo": "bar"},
                 headers={"X-Request-ID": request_id},
             ),
         )
@@ -222,26 +222,8 @@ class TestSyncHTTPClient(object):
         except BadRequestException as ex:
             assert (
                 str(ex)
-                == "(message=No message, request_id=request-123, error=example_error, error_description=Example error description)"
+                == "(message=No message, error=example_error, error_description=Example error description, foo=bar, request_id=request-123)"
             )
-        except Exception as ex:
-            assert ex.__class__ == BadRequestException
-
-    def test_bad_request_exceptions_exclude_expected_request_data(self):
-        request_id = "request-123"
-
-        self.http_client._client.request = MagicMock(
-            return_value=httpx.Response(
-                status_code=400,
-                json={"foo": "bar"},
-                headers={"X-Request-ID": request_id},
-            ),
-        )
-
-        try:
-            self.http_client.request("bad_place")
-        except BadRequestException as ex:
-            assert str(ex) == "(message=No message, request_id=request-123)"
         except Exception as ex:
             assert ex.__class__ == BadRequestException
 

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -222,7 +222,7 @@ class TestSyncHTTPClient(object):
         except BadRequestException as ex:
             assert (
                 str(ex)
-                == "(message=No message, error=example_error, error_description=Example error description, foo=bar, request_id=request-123)"
+                == "(message=No message, request_id=request-123, error=example_error, error_description=Example error description, foo=bar)"
             )
         except Exception as ex:
             assert ex.__class__ == BadRequestException

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -212,7 +212,11 @@ class TestSyncHTTPClient(object):
         self.http_client._client.request = MagicMock(
             return_value=httpx.Response(
                 status_code=400,
-                json={"error": error, "error_description": error_description, "foo": "bar"},
+                json={
+                    "error": error,
+                    "error_description": error_description,
+                    "foo": "bar",
+                },
                 headers={"X-Request-ID": request_id},
             ),
         )

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -2,76 +2,28 @@ from typing import Any, Mapping, Optional
 
 import httpx
 
-
 # Request related exceptions
 class BaseRequestException(Exception):
     def __init__(
         self,
         response: httpx.Response,
-        message: Optional[str] = None,
-        error: Optional[str] = None,
-        errors: Optional[Mapping[str, Any]] = None,
-        error_description: Optional[str] = None,
-        code: Optional[str] = None,
-        pending_authentication_token: Optional[str] = None,
+        response_json: Mapping[str, Any],
     ) -> None:
-        super(BaseRequestException, self).__init__(message)
+        super(BaseRequestException, self).__init__(response_json)
 
-        self.message = message
-        self.error = error
-        self.errors = errors
-        self.code = code
-        self.error_description = error_description
-        self.pending_authentication_token = pending_authentication_token
-        self.extract_and_set_response_related_data(response)
-
-    def extract_and_set_response_related_data(self, response: httpx.Response) -> None:
         self.response = response
-
-        try:
-            response_json = response.json()
-            self.message = response_json.get("message")
-            self.error = response_json.get("error")
-            self.errors = response_json.get("errors")
-            self.code = response_json.get("code")
-            self.error_description = response_json.get("error_description")
-            self.pending_authentication_token = response_json.get(
-                "pending_authentication_token"
-            )
-        except ValueError:
-            self.message = None
-            self.error = None
-            self.errors = None
-            self.code = None
-            self.error_description = None
-            self.pending_authentication_token = None
-
-        headers = response.headers
-        self.request_id = headers.get("X-Request-ID")
+        self.response_json = response_json
 
     def __str__(self) -> str:
-        message = self.message or "No message"
+        message = self.response_json.get("message") or "No message"
         exception = "(message=%s" % message
 
-        if self.request_id is not None:
-            exception += ", request_id=%s" % self.request_id
+        for key, value in self.response_json.items():
+            if key != "message":
+                exception += ", %s=%s" % (key, value)
 
-        if self.code is not None:
-            exception += ", code=%s" % self.code
-
-        if self.error is not None:
-            exception += ", error=%s" % self.error
-
-        if self.errors is not None:
-            exception += ", errors=%s" % self.errors
-
-        if self.error_description is not None:
-            exception += ", error_description=%s" % self.error_description
-
-        if self.pending_authentication_token is not None:
-            exception += (
-                ", pending_authentication_token=%s" % self.pending_authentication_token
-            )
+        request_id = self.response.headers.get("X-Request-ID")
+        exception += ", request_id=%s" % request_id
 
         return exception + ")"
 

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -2,6 +2,7 @@ from typing import Any, Mapping, Optional
 
 import httpx
 
+
 # Request related exceptions
 class BaseRequestException(Exception):
     def __init__(

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -8,7 +8,7 @@ class BaseRequestException(Exception):
     def __init__(
         self,
         response: httpx.Response,
-        response_json: Mapping[str, Any],
+        response_json: Optional[Mapping[str, Any]],
     ) -> None:
         super(BaseRequestException, self).__init__(response_json)
 

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -17,7 +17,7 @@ class BaseRequestException(Exception):
         self.message = self.extractFromJson("message", "No message")
         self.error = self.extractFromJson("error", None)
         self.errors = self.extractFromJson("errors", None)
-        self.code = self.extractFromJson("code", None )
+        self.code = self.extractFromJson("code", None)
         self.error_description = self.extractFromJson("error_description", None)
 
         self.request_id = response.headers.get("X-Request-ID")

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -14,16 +14,29 @@ class BaseRequestException(Exception):
         self.response = response
         self.response_json = response_json
 
+        self.message = self.extractFromJson("message", "No message")
+        self.error = self.extractFromJson("error", None)
+        self.errors = self.extractFromJson("errors", None)
+        self.code = self.extractFromJson("code", None )
+        self.error_description = self.extractFromJson("error_description", None)
+
+        self.request_id = response.headers.get("X-Request-ID")
+
+    def extractFromJson(self, key: str, alt: Optional[str] = None) -> Optional[str]:
+        if self.response_json is None:
+            return alt
+
+        return self.response_json.get(key, alt)
+
     def __str__(self) -> str:
-        message = self.response_json.get("message") or "No message"
-        exception = "(message=%s" % message
+        exception = "(message=%s" % self.message
 
-        for key, value in self.response_json.items():
-            if key != "message":
-                exception += ", %s=%s" % (key, value)
+        if self.response_json is not None:
+            for key, value in self.response_json.items():
+                if key != "message":
+                    exception += ", %s=%s" % (key, value)
 
-        request_id = self.response.headers.get("X-Request-ID")
-        exception += ", request_id=%s" % request_id
+        exception += ", request_id=%s" % self.request_id
 
         return exception + ")"
 

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -30,13 +30,12 @@ class BaseRequestException(Exception):
 
     def __str__(self) -> str:
         exception = "(message=%s" % self.message
+        exception += ", request_id=%s" % self.request_id
 
         if self.response_json is not None:
             for key, value in self.response_json.items():
                 if key != "message":
                     exception += ", %s=%s" % (key, value)
-
-        exception += ", request_id=%s" % self.request_id
 
         return exception + ")"
 

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -16,10 +16,10 @@ class BaseRequestException(Exception):
         self.response_json = response_json
 
         self.message = self.extractFromJson("message", "No message")
-        self.error = self.extractFromJson("error", None)
+        self.error = self.extractFromJson("error", "Unknown")
         self.errors = self.extractFromJson("errors", None)
         self.code = self.extractFromJson("code", None)
-        self.error_description = self.extractFromJson("error_description", None)
+        self.error_description = self.extractFromJson("error_description", "Unknown")
 
         self.request_id = response.headers.get("X-Request-ID")
 

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -15,15 +15,15 @@ class BaseRequestException(Exception):
         self.response = response
         self.response_json = response_json
 
-        self.message = self.extractFromJson("message", "No message")
-        self.error = self.extractFromJson("error", "Unknown")
-        self.errors = self.extractFromJson("errors", None)
-        self.code = self.extractFromJson("code", None)
-        self.error_description = self.extractFromJson("error_description", "Unknown")
+        self.message = self.extract_from_json("message", "No message")
+        self.error = self.extract_from_json("error", "Unknown")
+        self.errors = self.extract_from_json("errors", None)
+        self.code = self.extract_from_json("code", None)
+        self.error_description = self.extract_from_json("error_description", "Unknown")
 
         self.request_id = response.headers.get("X-Request-ID")
 
-    def extractFromJson(self, key: str, alt: Optional[str] = None) -> Optional[str]:
+    def extract_from_json(self, key: str, alt: Optional[str] = None) -> Optional[str]:
         if self.response_json is None:
             return alt
 

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -96,27 +96,15 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
         status_code = response.status_code
         if status_code >= 400 and status_code < 500:
             if status_code == 401:
-                raise AuthenticationException(response)
+                raise AuthenticationException(response, response_json)
             elif status_code == 403:
-                raise AuthorizationException(response)
+                raise AuthorizationException(response, response_json)
             elif status_code == 404:
-                raise NotFoundException(response)
+                raise NotFoundException(response, response_json)
 
-            error = (
-                response_json.get("error")
-                if response_json and "error" in response_json
-                else "Unknown"
-            )
-            error_description = (
-                response_json.get("error_description")
-                if response_json and "error_description" in response_json
-                else "Unknown"
-            )
-            raise BadRequestException(
-                response, error=error, error_description=error_description
-            )
+            raise BadRequestException(response, response_json)
         elif status_code >= 500 and status_code < 600:
-            raise ServerException(response)
+            raise ServerException(response, response_json)
 
     def _prepare_request(
         self,
@@ -158,10 +146,6 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
         # Remove any parameters that are None
         if params is not None:
             params = {k: v for k, v in params.items() if v is not None}
-
-        # Remove any body values that are None
-        if json is not None and isinstance(json, Mapping):
-            json = {k: v for k, v in json.items() if v is not None}
 
         # We'll spread these return values onto the HTTP client request method
         if bodyless_http_method:

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -181,7 +181,7 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
             try:
                 response_json = response.json()
             except ValueError:
-                raise ServerException(response)
+                raise ServerException(response, None)
 
         self._maybe_raise_error_by_status_code(response, response_json)
 

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -147,6 +147,10 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
         if params is not None:
             params = {k: v for k, v in params.items() if v is not None}
 
+        # Remove any body values that are None
+        if json is not None and isinstance(json, Mapping):
+            json = {k: v for k, v in json.items() if v is not None}
+
         # We'll spread these return values onto the HTTP client request method
         if bodyless_http_method:
             return {


### PR DESCRIPTION
## Description
Exceptions were only returning specific hardcoded values, which isn't accurate any more since an error can have a plethora of parameters in it. 

This fixes it by dumping the contents of the API response into the error object, giving the user all the information they need to fix the error.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.