### PR TITLE
Add missing organization membership types to Event type union

### DIFF
--- a/workos/types/events/event.py
+++ b/workos/types/events/event.py
@@ -49,6 +49,12 @@ from workos.types.user_management.magic_auth import MagicAuthCommon
 from workos.types.user_management.password_reset import PasswordResetCommon
 
 
+# README
+# When adding a new event type, ensure the new event class is
+# added to the Event union type at the bottom of this file, and
+# the event name is added to the EventType union type in event_type.py.
+
+
 class AuthenticationEmailVerificationSucceededEvent(
     EventModel[AuthenticationEmailVerificationSucceededPayload,]
 ):
@@ -264,6 +270,9 @@ Event = Annotated[
         OrganizationUpdatedEvent,
         OrganizationDomainVerificationFailedEvent,
         OrganizationDomainVerifiedEvent,
+        OrganizationMembershipCreatedEvent,
+        OrganizationMembershipDeletedEvent,
+        OrganizationMembershipUpdatedEvent,
         PasswordResetCreatedEvent,
         RoleCreatedEvent,
         RoleDeletedEvent,

--- a/workos/types/events/event_type.py
+++ b/workos/types/events/event_type.py
@@ -1,5 +1,8 @@
 from typing import Literal, TypeVar
 
+# README
+# When adding a new event type, ensure a new event class is created
+# and added to the Event class union type in event.py.
 
 EventType = Literal[
     "authentication.email_verification_succeeded",


### PR DESCRIPTION
## Description
Add missing organization membership types to Event type union. Fixes #362.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.