### PR TITLE
Bump version to 5.4.2

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "5.4.1"
+__version__ = "5.4.2"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
## Description
Bump version to 5.4.2.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.