### PR TITLE
Fix dsync.activated event parsing for Event API when domains present

### DIFF
--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from workos.typing.webhooks import WebhookTypeAdapter
 from workos.webhooks import Webhooks
 
 
@@ -122,3 +123,32 @@ class TestWebhooks(object):
         )
         assert type(result).__name__ == "UntypedWebhook"
         assert result.dict() == json.loads(mock_unknown_webhook_body)
+
+    def test_validate_dsync_activated_event(self):
+        event_body = {
+            "id": "event_01J8SX5FTXYD2YFWVTGJY49EM6",
+            "data": {
+                "id": "directory_01EHWNC0FCBHZ3BJ7EGKYXK0E6",
+                "name": "Foo Corp's Directory",
+                "type": "generic scim v2.0",
+                "state": "active",
+                "object": "directory",
+                "domains": [
+                    {
+                        "id": "org_domain_01EZTR5N6Y9RQKHK2E9F31KZX6",
+                        "domain": "foo-corp.com",
+                        "object": "organization_domain",
+                    }
+                ],
+                "created_at": "2021-06-25T19:07:33.155Z",
+                "updated_at": "2021-06-25T19:07:33.155Z",
+                "external_key": "UWuccu6o1E0GqkYs",
+                "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
+            },
+            "event": "dsync.activated",
+            "created_at": "2021-06-25T19:07:33.155Z",
+        }
+
+        result = WebhookTypeAdapter.validate_json(json.dumps(event_body))
+        assert type(result).__name__ == "DirectoryActivatedWebhook"
+        assert result.dict() == event_body

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -124,6 +124,8 @@ class TestWebhooks(object):
         assert type(result).__name__ == "UntypedWebhook"
         assert result.dict() == json.loads(mock_unknown_webhook_body)
 
+    # TODO: This test should be updated in the next major version to expect
+    # a DirectoryActivatedWebhook return type.
     def test_validate_dsync_activated_event(self):
         event_body = {
             "id": "event_01J8SX5FTXYD2YFWVTGJY49EM6",
@@ -150,5 +152,5 @@ class TestWebhooks(object):
         }
 
         result = WebhookTypeAdapter.validate_json(json.dumps(event_body))
-        assert type(result).__name__ == "DirectoryActivatedWebhook"
+        assert type(result).__name__ == "UntypedWebhook"
         assert result.dict() == event_body

--- a/tests/utils/fixtures/mock_event.py
+++ b/tests/utils/fixtures/mock_event.py
@@ -3,6 +3,7 @@ import datetime
 from workos.types.events import DirectoryActivatedEvent
 from workos.types.events.directory_payload_with_legacy_fields import (
     DirectoryPayloadWithLegacyFields,
+    DirectoryPayloadWithLegacyFieldsForEventsApi,
 )
 
 
@@ -13,7 +14,7 @@ class MockEvent(DirectoryActivatedEvent):
             object="event",
             id=id,
             event="dsync.activated",
-            data=DirectoryPayloadWithLegacyFields(
+            data=DirectoryPayloadWithLegacyFieldsForEventsApi(
                 object="directory",
                 id="dir_1234",
                 organization_id="organization_id",

--- a/workos/types/events/directory_payload_with_legacy_fields.py
+++ b/workos/types/events/directory_payload_with_legacy_fields.py
@@ -5,10 +5,25 @@ from workos.types.events.directory_payload import DirectoryPayload
 
 class MinimalOrganizationDomain(WorkOSModel):
     id: str
+    # TODO: This should be domain: str in the
+    # next major version to fix object parsing.
+    organization_id: str
+    object: Literal["organization_domain"]
+
+
+# TODO: This class should be removed in the next major version once MinimalOrganizationDomain is updated.
+class MinimalOrganizationDomainForEventsApi(WorkOSModel):
+    id: str
     domain: str
     object: Literal["organization_domain"]
 
 
 class DirectoryPayloadWithLegacyFields(DirectoryPayload):
     domains: Sequence[MinimalOrganizationDomain]
+    external_key: str
+
+
+# TODO: This class should be removed in the next major version once MinimalOrganizationDomain is updated.
+class DirectoryPayloadWithLegacyFieldsForEventsApi(DirectoryPayload):
+    domains: Sequence[MinimalOrganizationDomainForEventsApi]
     external_key: str

--- a/workos/types/events/directory_payload_with_legacy_fields.py
+++ b/workos/types/events/directory_payload_with_legacy_fields.py
@@ -5,7 +5,7 @@ from workos.types.events.directory_payload import DirectoryPayload
 
 class MinimalOrganizationDomain(WorkOSModel):
     id: str
-    organization_id: str
+    domain: str
     object: Literal["organization_domain"]
 
 

--- a/workos/types/events/event.py
+++ b/workos/types/events/event.py
@@ -28,6 +28,7 @@ from workos.types.events.directory_group_with_previous_attributes import (
 from workos.types.events.directory_payload import DirectoryPayload
 from workos.types.events.directory_payload_with_legacy_fields import (
     DirectoryPayloadWithLegacyFields,
+    DirectoryPayloadWithLegacyFieldsForEventsApi,
 )
 from workos.types.events.directory_user_with_previous_attributes import (
     DirectoryUserWithPreviousAttributes,
@@ -119,7 +120,7 @@ class ConnectionDeletedEvent(EventModel[Connection]):
     event: Literal["connection.deleted"]
 
 
-class DirectoryActivatedEvent(EventModel[DirectoryPayloadWithLegacyFields]):
+class DirectoryActivatedEvent(EventModel[DirectoryPayloadWithLegacyFieldsForEventsApi]):
     event: Literal["dsync.activated"]
 
 

--- a/workos/types/events/event_model.py
+++ b/workos/types/events/event_model.py
@@ -27,6 +27,7 @@ from workos.types.events.directory_group_with_previous_attributes import (
 from workos.types.events.directory_payload import DirectoryPayload
 from workos.types.events.directory_payload_with_legacy_fields import (
     DirectoryPayloadWithLegacyFields,
+    DirectoryPayloadWithLegacyFieldsForEventsApi,
 )
 from workos.types.events.directory_user_with_previous_attributes import (
     DirectoryUserWithPreviousAttributes,
@@ -63,6 +64,8 @@ EventPayload = TypeVar(
     ConnectionPayloadWithLegacyFields,
     DirectoryPayload,
     DirectoryPayloadWithLegacyFields,
+    # TODO: Remove once merged with DirectoryPayloadWithLegacyFields in next major release.
+    DirectoryPayloadWithLegacyFieldsForEventsApi,
     DirectoryGroup,
     DirectoryGroupWithPreviousAttributes,
     DirectoryUser,


### PR DESCRIPTION
## Description
Fix incorrect `dsync.activated` domains type for Events API, causing a parsing error when listing `dsync.activated` events with domains.

This PR leaves the webhooks event payload as a dictionary. This will be changed in the next major version.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.