### PR TITLE
Add "role" to profile

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -29,6 +29,7 @@ class SSOFixtures:
             idp_id="",
             first_name=None,
             last_name=None,
+            profile=None,
             groups=None,
             raw_attributes={},
         ).dict()

--- a/tests/utils/fixtures/mock_profile.py
+++ b/tests/utils/fixtures/mock_profile.py
@@ -10,6 +10,7 @@ class MockProfile(Profile):
             email="demo@workos-okta.com",
             first_name="WorkOS",
             last_name="Demo",
+            role={"slug": "admin"},
             groups=["Admins", "Developers"],
             organization_id="org_01FG53X8636WSNW2WEKB2C31ZB",
             connection_id="conn_01EMH8WAK20T42N2NBMNBCYHAG",

--- a/workos/types/sso/profile.py
+++ b/workos/types/sso/profile.py
@@ -2,7 +2,10 @@ from typing import Any, Literal, Mapping, Optional, Sequence
 from workos.types.sso.connection import ConnectionType
 from workos.types.workos_model import WorkOSModel
 from workos.typing.literals import LiteralOrUntyped
+from typing_extensions import TypedDict
 
+class ProfileRole(TypedDict):
+    slug: str
 
 class Profile(WorkOSModel):
     """Representation of a User Profile as returned by WorkOS through the SSO feature."""
@@ -16,6 +19,7 @@ class Profile(WorkOSModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     idp_id: str
+    role: Optional[ProfileRole] = None
     groups: Optional[Sequence[str]] = None
     raw_attributes: Mapping[str, Any]
 

--- a/workos/types/sso/profile.py
+++ b/workos/types/sso/profile.py
@@ -4,8 +4,10 @@ from workos.types.workos_model import WorkOSModel
 from workos.typing.literals import LiteralOrUntyped
 from typing_extensions import TypedDict
 
+
 class ProfileRole(TypedDict):
     slug: str
+
 
 class Profile(WorkOSModel):
     """Representation of a User Profile as returned by WorkOS through the SSO feature."""


### PR DESCRIPTION
## Description

Adds "role" property to profile.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

[Docs PR](https://github.com/workos/workos/pull/31033/)

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.