### PR TITLE
Add `oauth_tokens` to AuthkitAuthenticationResponse

### DIFF
--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -1,5 +1,6 @@
 from typing import Literal, Optional, TypeVar
 from workos.types.user_management.impersonator import Impersonator
+from workos.types.user_management.oauth_tokens import OAuthTokens
 from workos.types.user_management.user import User
 from workos.types.workos_model import WorkOSModel
 
@@ -28,6 +29,7 @@ class AuthenticationResponse(_AuthenticationResponseBase):
     impersonator: Optional[Impersonator] = None
     organization_id: Optional[str] = None
     user: User
+    oauth_tokens: Optional[OAuthTokens] = None
 
 
 class AuthKitAuthenticationResponse(AuthenticationResponse):

--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -29,13 +29,13 @@ class AuthenticationResponse(_AuthenticationResponseBase):
     impersonator: Optional[Impersonator] = None
     organization_id: Optional[str] = None
     user: User
-    oauth_tokens: Optional[OAuthTokens] = None
 
 
 class AuthKitAuthenticationResponse(AuthenticationResponse):
     """Representation of a WorkOS User and Organization ID response."""
 
     impersonator: Optional[Impersonator] = None
+    oauth_tokens: Optional[OAuthTokens] = None
 
 
 class RefreshTokenAuthenticationResponse(_AuthenticationResponseBase):

--- a/workos/types/user_management/oauth_tokens.py
+++ b/workos/types/user_management/oauth_tokens.py
@@ -1,4 +1,5 @@
-from typing import Literal, List
+from typing import Literal, Sequence
+
 from workos.types.workos_model import WorkOSModel
 
 OAuthTokensProvidersType = Literal[
@@ -16,4 +17,4 @@ class OAuthTokens(WorkOSModel):
     access_token: str
     refresh_token: str
     expires_at: int
-    scopes: List[str]
+    scopes: Sequence[str]

--- a/workos/types/user_management/oauth_tokens.py
+++ b/workos/types/user_management/oauth_tokens.py
@@ -1,0 +1,19 @@
+from typing import Literal, List
+from workos.types.workos_model import WorkOSModel
+
+OAuthTokensProvidersType = Literal[
+    "AppleOauth",
+    "GitHubOauth",
+    "GoogleOauth",
+    "MicrosoftOauth",
+]
+
+
+class OAuthTokens(WorkOSModel):
+    """Representation of a WorkOS Dashboard member impersonating a user"""
+
+    provider: OAuthTokensProvidersType
+    access_token: str
+    refresh_token: str
+    expires_at: int
+    scopes: List[str]


### PR DESCRIPTION
## Description

Created a new `OAuthTokens` model to represent OAuth credentials, including provider, access token, refresh token, expiration, and scopes. Integrated this new model into the `AuthenticationResponse` class, adding an optional field for OAuth tokens.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.