### PR TITLE
Add `"Passkey"` to `AuthenticationMethod`

### DIFF
--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -8,6 +8,7 @@ from workos.types.workos_model import WorkOSModel
 AuthenticationMethod = Literal[
     "SSO",
     "Password",
+    "Passkey",
     "AppleOAuth",
     "GitHubOAuth",
     "GoogleOAuth",


### PR DESCRIPTION
## Description

Adds `"Passkey"` as a possible value of `AuthenticationMethod`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.