### PR TITLE
Add prompt option to creating authorization urls

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -212,6 +212,26 @@ class TestUserManagementBase(UserManagementFixtures):
             "response_type": RESPONSE_TYPE_CODE,
         }
 
+    def test_authorization_url_has_expected_query_params_with_prompt(self):
+        provider = "GoogleOAuth"
+        redirect_uri = "https://localhost/auth/callback"
+        prompt = "consent"
+        authorization_url = self.user_management.get_authorization_url(
+            provider=provider,
+            redirect_uri=redirect_uri,
+            prompt=prompt,
+        )
+
+        parsed_url = urlparse(authorization_url)
+        assert parsed_url.path == "/user_management/authorize"
+        assert dict(parse_qsl(str(parsed_url.query))) == {
+            "client_id": self.http_client.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+            "provider": provider,
+            "prompt": prompt,
+        }
+
     def test_authorization_url_has_expected_query_params_with_domain_hint(self):
         connection_id = "connection_123"
         redirect_uri = "https://localhost/auth/callback"

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -350,7 +350,9 @@ class UserManagementModule(Protocol):
             state (str): An encoded string passed to WorkOS that'd be preserved through the authentication workflow, passed
                 back as a query parameter. (Optional)
             code_challenge (str): Code challenge is derived from the code verifier used for the PKCE flow. (Optional)
-            prompt (str): The prompt parameter can be used to specify whether the user should be prompted for credentials or not.
+            prompt (str): Used to specify whether the upstream provider should prompt the user for credentials or other
+                consent. Valid values depend on the provider. Currently only applies to provider values of 'GoogleOAuth',
+                'MicrosoftOAuth', or 'GitHubOAuth'. (Optional)
 
         Returns:
             str: URL to redirect a User to to begin the OAuth workflow with WorkOS

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -325,6 +325,7 @@ class UserManagementModule(Protocol):
         connection_id: Optional[str] = None,
         organization_id: Optional[str] = None,
         code_challenge: Optional[str] = None,
+        prompt: Optional[str] = None,
     ) -> str:
         """Generate an OAuth 2.0 authorization URL.
 
@@ -349,6 +350,7 @@ class UserManagementModule(Protocol):
             state (str): An encoded string passed to WorkOS that'd be preserved through the authentication workflow, passed
                 back as a query parameter. (Optional)
             code_challenge (str): Code challenge is derived from the code verifier used for the PKCE flow. (Optional)
+            prompt (str): The prompt parameter can be used to specify whether the user should be prompted for credentials or not.
 
         Returns:
             str: URL to redirect a User to to begin the OAuth workflow with WorkOS
@@ -379,6 +381,8 @@ class UserManagementModule(Protocol):
         if code_challenge:
             params["code_challenge"] = code_challenge
             params["code_challenge_method"] = "S256"
+        if prompt is not None:
+            params["prompt"] = prompt
 
         return RequestHelper.build_url_with_query_params(
             base_url=self._client_configuration.base_url,


### PR DESCRIPTION
## Description

This changset adds the prompt option to generating oauth authorization urls.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.