### PR TITLE
Adds session helpers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 WorkOS
+Copyright (c) 2024 WorkOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+flake8
+pytest==8.3.2
+pytest-asyncio==0.23.8
+pytest-cov==5.0.0
+six==1.16.0
+black==24.4.2
+twine==5.1.1
+mypy==1.12.0
+httpx>=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+httpx>=0.27.0
+pydantic==2.9.2
+PyJWT==2.9.0
+cryptography==43.0.3

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,11 @@ about = {}
 with open(os.path.join(base_dir, "workos", "__about__.py")) as f:
     exec(f.read(), about)
 
+def read_requirements(filename):
+    with open(filename) as f:
+        return [line.strip() for line in f
+                if line.strip() and not line.startswith('#')]
+
 setup(
     name=about["__package_name__"],
     version=about["__version__"],
@@ -27,19 +32,9 @@ setup(
     ),
     zip_safe=False,
     license=about["__license__"],
-    install_requires=["httpx>=0.27.0", "pydantic==2.9.2"],
+    install_requires=read_requirements("requirements.txt"),
     extras_require={
-        "dev": [
-            "flake8",
-            "pytest==8.3.2",
-            "pytest-asyncio==0.23.8",
-            "pytest-cov==5.0.0",
-            "six==1.16.0",
-            "black==24.4.2",
-            "twine==5.1.1",
-            "mypy==1.12.0",
-            "httpx>=0.27.0",
-        ],
+        "dev": read_requirements("requirements-dev.txt"),
         ":python_version<'3.4'": ["enum34"],
     },
     classifiers=[

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,333 @@
+import pytest
+from unittest.mock import Mock, patch
+import jwt
+from jwt import PyJWKClient
+from datetime import datetime, timezone
+
+from workos.session import SessionModule
+from workos.types.user_management.authentication_response import RefreshTokenAuthenticationResponse
+from workos.types.user_management.session import (
+    AuthenticateWithSessionCookieFailureReason,
+    AuthenticateWithSessionCookieSuccessResponse,
+    RefreshWithSessionCookieErrorResponse,
+    RefreshWithSessionCookieSuccessResponse,
+)
+from workos.types.user_management.user import User
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+@pytest.fixture(scope="session")
+def TEST_CONSTANTS():
+    # Generate RSA key pair for testing
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048
+    )
+
+    public_key = private_key.public_key()
+
+    # Get the private key in PEM format
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+
+    return {
+        "COOKIE_PASSWORD": "pfSqwTFXUTGEBBD1RQh2kt/oNJYxBgaoZan4Z8sMrKU=",
+        "SESSION_DATA": "session_data",
+        "CLIENT_ID": "client_123",
+        "USER_ID": "user_123",
+        "SESSION_ID": "session_123",
+        "ORGANIZATION_ID": "organization_123",
+        "CURRENT_TIMESTAMP": str(datetime.now(timezone.utc)),
+        "PRIVATE_KEY": private_pem,
+        "PUBLIC_KEY": public_key,
+        "TEST_TOKEN": jwt.encode(
+            {
+                "sid": "session_123",
+                "org_id": "organization_123",
+                "role": "admin",
+                "permissions": ["read"],
+                "entitlements": ["feature_1"],
+                "exp": int(datetime.now(timezone.utc).timestamp()) + 3600,
+                "iat": int(datetime.now(timezone.utc).timestamp()),
+            },
+            private_pem,
+            algorithm="RS256"
+        )
+    }
+
+@pytest.fixture
+def mock_user_management(TEST_CONSTANTS):
+    mock_jwks = Mock(spec=PyJWKClient)
+    mock_jwk_set = Mock()
+    mock_jwk_set.keys = [Mock(Algorithm="RS256")]
+    mock_jwks.get_jwk_set.return_value = mock_jwk_set
+
+
+
+    mock = Mock()
+    mock.get_jwks_url.return_value = "https://api.workos.com/user_management/sso/jwks/client_123"
+    mock.authenticate_with_refresh_token.return_value = RefreshTokenAuthenticationResponse(
+        **{
+            "access_token": "access_token_123",
+            "refresh_token": "refresh_token_123",
+            "user": {
+                "object": "user",
+                "id": TEST_CONSTANTS["USER_ID"],
+                "email": "user@example.com",
+                "first_name": "Test",
+                "last_name": "User",
+                "email_verified": True,
+                "created_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+                "updated_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+            }
+        }
+    )
+    return mock
+
+def test_initialize_session_module(TEST_CONSTANTS, mock_user_management):
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data=TEST_CONSTANTS["SESSION_DATA"],
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    assert session.client_id == TEST_CONSTANTS["CLIENT_ID"]
+    assert session.cookie_password is not None
+
+def test_initialize_without_cookie_password(mock_user_management):
+    with pytest.raises(ValueError, match="cookie_password is required"):
+        SessionModule(
+            user_management=mock_user_management,
+            client_id="client_123",
+            session_data="session_data",
+            cookie_password=""
+        )
+
+def test_authenticate_no_session_cookie_provided(TEST_CONSTANTS, mock_user_management):
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data=None,
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    response = session.authenticate()
+
+    assert response.reason == AuthenticateWithSessionCookieFailureReason.NO_SESSION_COOKIE_PROVIDED
+
+def test_authenticate_invalid_session_cookie(TEST_CONSTANTS, mock_user_management):
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data="invalid_session_data",
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    response = session.authenticate()
+
+    assert response.reason == AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+
+def test_authenticate_invalid_jwt(TEST_CONSTANTS, mock_user_management):
+    invalid_session_data = SessionModule.seal_data({ "access_token": "invalid_session_data" }, TEST_CONSTANTS["COOKIE_PASSWORD"])
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data=invalid_session_data,
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    response = session.authenticate()
+
+    assert response.reason == AuthenticateWithSessionCookieFailureReason.INVALID_JWT
+
+def test_authenticate_success(TEST_CONSTANTS, mock_user_management):
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data=TEST_CONSTANTS["SESSION_DATA"],
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    # Mock the session data that would be unsealed
+    mock_session = {
+        "access_token": jwt.encode(
+            {
+                "sid": TEST_CONSTANTS["SESSION_ID"],
+                "org_id": TEST_CONSTANTS["ORGANIZATION_ID"],
+                "role": "admin",
+                "permissions": ["read"],
+                "entitlements": ["feature_1"],
+                "exp": int(datetime.now(timezone.utc).timestamp()) + 3600,
+                "iat": int(datetime.now(timezone.utc).timestamp()),
+            },
+            TEST_CONSTANTS["PRIVATE_KEY"],
+            algorithm="RS256"
+        ),
+        "user": {
+            "object": "user",
+            "id": TEST_CONSTANTS["USER_ID"],
+            "email": "user@example.com",
+            "email_verified": True,
+            "created_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+            "updated_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+        },
+        "impersonator": None
+    }
+
+    # Mock the JWT payload that would be decoded
+    mock_jwt_payload = {
+        "sid": TEST_CONSTANTS["SESSION_ID"],
+        "org_id": TEST_CONSTANTS["ORGANIZATION_ID"],
+        "role": "admin",
+        "permissions": ["read"],
+        "entitlements": ["feature_1"]
+    }
+
+    with (
+        # Mock unsealing the session data
+        patch.object(
+            SessionModule,
+            "unseal_data",
+            return_value=mock_session
+        ),
+        # Mock JWT validation
+        patch.object(
+            session,
+            "is_valid_jwt",
+            return_value=True
+        ),
+        # Mock JWT decoding
+        patch(
+            "jwt.decode",
+            return_value=mock_jwt_payload
+        ),
+        # Mock JWT signing key retrieval
+        patch.object(
+            session.jwks,
+            "get_signing_key_from_jwt",
+            return_value=Mock(key=TEST_CONSTANTS["PUBLIC_KEY"])
+        )
+    ):
+        response = session.authenticate()
+
+        assert isinstance(response, AuthenticateWithSessionCookieSuccessResponse)
+        assert response.authenticated is True
+        assert response.session_id == TEST_CONSTANTS["SESSION_ID"]
+        assert response.organization_id == TEST_CONSTANTS["ORGANIZATION_ID"]
+        assert response.role == "admin"
+        assert response.permissions == ["read"]
+        assert response.entitlements == ["feature_1"]
+        assert response.user.id == TEST_CONSTANTS["USER_ID"]
+        assert response.impersonator is None
+
+def test_refresh_invalid_session_cookie(TEST_CONSTANTS, mock_user_management):
+    session = SessionModule(
+        user_management=mock_user_management,
+        client_id=TEST_CONSTANTS["CLIENT_ID"],
+        session_data="invalid_session_data",
+        cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+    )
+
+    response = session.refresh()
+
+    assert isinstance(response, RefreshWithSessionCookieErrorResponse)
+    assert response.reason == AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+
+def test_refresh_success(TEST_CONSTANTS, mock_user_management):
+     # Create mock JWKS client
+    mock_jwks = Mock(spec=PyJWKClient)
+    mock_signing_key = Mock()
+    mock_signing_key.key = TEST_CONSTANTS["PUBLIC_KEY"]
+    mock_jwks.get_signing_key_from_jwt.return_value = mock_signing_key
+
+    test_user = {
+        "object": "user",
+        "id": TEST_CONSTANTS["USER_ID"],
+        "email": "user@example.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "email_verified": True,
+        "created_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+        "updated_at": TEST_CONSTANTS["CURRENT_TIMESTAMP"],
+    }
+
+    session_data = SessionModule.seal_data({
+        "refresh_token": "refresh_token_12345",
+        "user": test_user
+    }, TEST_CONSTANTS["COOKIE_PASSWORD"])
+
+    mock_response = {
+        "access_token": TEST_CONSTANTS["TEST_TOKEN"],
+        "refresh_token": "refresh_token_123",
+        "sealed_session": session_data,
+        "user": test_user
+    }
+
+    mock_user_management.authenticate_with_refresh_token.return_value = RefreshTokenAuthenticationResponse(
+        **mock_response
+    )
+
+    with (
+        patch(
+            'workos.session.PyJWKClient',
+            return_value=mock_jwks
+        ),
+    ):
+        session = SessionModule(
+            user_management=mock_user_management,
+            client_id=TEST_CONSTANTS["CLIENT_ID"],
+            session_data=session_data,
+            cookie_password=TEST_CONSTANTS["COOKIE_PASSWORD"]
+        )
+
+        with (
+            patch.object(
+                session,
+                "is_valid_jwt",
+                return_value=True
+            ),
+            patch(
+                "jwt.decode",
+                return_value={
+                    "sid": TEST_CONSTANTS["SESSION_ID"],
+                    "org_id": TEST_CONSTANTS["ORGANIZATION_ID"],
+                    "role": "admin",
+                    "permissions": ["read"],
+                    "entitlements": ["feature_1"]
+                }
+            )
+        ):
+            response = session.refresh()
+
+            assert isinstance(response, RefreshWithSessionCookieSuccessResponse)
+            assert response.authenticated is True
+            assert response.user.id == test_user["id"]
+
+        # Verify the refresh token was used correctly
+        mock_user_management.authenticate_with_refresh_token.assert_called_once_with(
+            refresh_token="refresh_token_12345",
+            organization_id=None,
+            session={
+                "seal_session": True,
+                "cookie_password": TEST_CONSTANTS["COOKIE_PASSWORD"]
+            }
+        )
+
+
+def test_seal_data(TEST_CONSTANTS):
+    test_data = {"test": "data"}
+    sealed = SessionModule.seal_data(test_data, TEST_CONSTANTS["COOKIE_PASSWORD"])
+    assert isinstance(sealed, str)
+
+    # Test unsealing
+    unsealed = SessionModule.unseal_data(sealed, TEST_CONSTANTS["COOKIE_PASSWORD"])
+    assert unsealed == test_data
+
+def test_unseal_invalid_data(TEST_CONSTANTS):
+    with pytest.raises(Exception):  # Adjust exception type based on your implementation
+        SessionModule.unseal_data("invalid_sealed_data", TEST_CONSTANTS["COOKIE_PASSWORD"])

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -60,9 +60,12 @@ class UserManagementFixtures:
 
     @pytest.fixture
     def mock_auth_refresh_token_response(self):
+        user = MockUser("user_01H7ZGXFP5C6BBQY6Z7277ZCT0").dict()
+
         return {
             "access_token": "access_token_12345",
             "refresh_token": "refresh_token_12345",
+            "user": user,
         }
 
     @pytest.fixture

--- a/workos/session.py
+++ b/workos/session.py
@@ -1,9 +1,155 @@
+import json
+from typing import Any, Dict, List, Optional, Union
+import jwt
+from jwt import PyJWKClient
+from cryptography.fernet import Fernet
 
-from typing import Protocol, Union
+from workos.types.user_management.session import (
+    AuthenticateWithSessionCookieFailureReason,
+    AuthenticateWithSessionCookieSuccessResponse,
+    AuthenticateWithSessionCookieErrorResponse,
+)
 
-from workos.types.user_management.session import AuthenticateWithSessionCookieSuccessResponse, AuthenticateWithSessionCookieErrorResponse
+class SessionModule:
+    def __init__(
+        self,
+        *,
+        user_management: Any,
+        client_id: str,
+        session_data: str,
+        cookie_password: str
+    ) -> None:
+        # If the cookie password is not provided, throw an error
+        if cookie_password is None or cookie_password == "":
+            raise ValueError("cookie_password is required")
 
-class SessionModule(Protocol):
+        self.user_management = user_management
+        self.client_id = client_id
+        self.session_data = session_data
+        self.cookie_password = cookie_password
 
-    def authenticate(self) -> Union[AuthenticateWithSessionCookieSuccessResponse, AuthenticateWithSessionCookieErrorResponse]:
-        ...
+        self.jwks = self.create_remote_jwk_set(
+            self.user_management.get_jwks_url()
+        )
+        self.jwk_algorithms = [str(key.Algorithm) for key in self.jwks]
+
+        for key in self.jwks:
+            print("Key properties:", dir(key))  # This will show all available attributes
+            print("Algorithm:", key.Algorithm)
+            print("Key type:", key.key_type)
+
+    def authenticate(
+        self,
+    ) -> Union[
+        AuthenticateWithSessionCookieSuccessResponse,
+        AuthenticateWithSessionCookieErrorResponse,
+    ]:
+        if self.session_data is None:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.NO_SESSION_COOKIE_PROVIDED
+            )
+
+        try:
+            session = self.unseal_data(self.session_data, self.cookie_password)
+        except Exception:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+            )
+
+        if not session["access_token"]:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+            )
+
+        if not self.is_valid_jwt(session["access_token"]):
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.INVALID_JWT
+            )
+
+        decoded = jwt.decode(
+            session["access_token"], self.jwks, algorithms=self.jwk_algorithms
+        )
+
+        return AuthenticateWithSessionCookieSuccessResponse(
+            authenticated=True,
+            session_id=decoded["sid"],
+            organization_id=decoded["org_id"],
+            role=decoded["role"],
+            permissions=decoded["permissions"],
+            entitlements=decoded["entitlements"],
+            user=session["user"],
+            impersonator=session["impersonator"],
+            reason=None,
+        )
+
+    def refresh(self, options: Optional[Dict[str, Any]] = None) -> Union[
+        AuthenticateWithSessionCookieSuccessResponse,
+        AuthenticateWithSessionCookieErrorResponse,
+    ]:
+        cookie_password = options.get("cookie_password", self.cookie_password)
+        organization_id = options.get("organization_id", None)
+
+        try:
+            session = self.unseal_data(self.session_data, cookie_password)
+        except Exception:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+            )
+
+        if not session["refresh_token"] or not session["user"]:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE
+            )
+
+        try:
+            auth_response = self.user_management.authenticate_with_refresh_token(
+                refresh_token=session["refresh_token"],
+                organization_id=organization_id,
+            )
+
+            self.session_data = auth_response.sealed_session
+            self.cookie_password = cookie_password
+
+            return AuthenticateWithSessionCookieSuccessResponse(
+                authenticated=True,
+                sealed_session=auth_response.sealed_session,
+                session=auth_response,
+                reason=None,
+            )
+        except Exception as e:
+            return AuthenticateWithSessionCookieErrorResponse(
+                authenticated=False, reason=str(e)
+            )
+
+    def get_logout_url(self) -> str:
+        auth_response = self.authenticate()
+
+        if not auth_response["authenticated"]:
+            raise ValueError(auth_response["reason"])
+
+        return self.user_management.get_logout_url(
+            session_id=auth_response["session_id"]
+        )
+
+    def create_remote_jwk_set(self, url: str) -> List[Dict[str, Any]]:
+        jwks_client = PyJWKClient(url)
+        return jwks_client.get_signing_keys()
+
+    def is_valid_jwt(self, token: str) -> bool:
+        try:
+            jwt.decode(token, self.jwks, algorithms=self.jwk_algorithms)
+            return True
+        except jwt.exceptions.InvalidTokenError as error:
+            print("invalid token", error)
+            return False
+
+    @staticmethod
+    def seal_data(data: Dict[str, Any], key: str) -> str:
+        fernet = Fernet(key)
+        # take the data and encrypt it with the key using fernet
+        return fernet.encrypt(json.dumps(data).encode())
+
+    @staticmethod
+    def unseal_data(sealed_data: str, key: str) -> Dict[str, Any]:
+        fernet = Fernet(key)
+        return json.loads(fernet.decrypt(sealed_data).decode())

--- a/workos/session.py
+++ b/workos/session.py
@@ -1,0 +1,9 @@
+
+from typing import Protocol, Union
+
+from workos.types.user_management.session import AuthenticateWithSessionCookieSuccessResponse, AuthenticateWithSessionCookieErrorResponse
+
+class SessionModule(Protocol):
+
+    def authenticate(self) -> Union[AuthenticateWithSessionCookieSuccessResponse, AuthenticateWithSessionCookieErrorResponse]:
+        ...

--- a/workos/types/user_management/authenticate_with_common.py
+++ b/workos/types/user_management/authenticate_with_common.py
@@ -1,5 +1,6 @@
 from typing import Literal, Union
 from typing_extensions import TypedDict
+from workos.types.user_management.session import SessionConfig
 
 
 class AuthenticateWithBaseParameters(TypedDict):
@@ -17,6 +18,7 @@ class AuthenticateWithCodeParameters(AuthenticateWithBaseParameters):
     code: str
     code_verifier: Union[str, None]
     grant_type: Literal["authorization_code"]
+    session: Union[SessionConfig, None]
 
 
 class AuthenticateWithMagicAuthParameters(AuthenticateWithBaseParameters):

--- a/workos/types/user_management/authenticate_with_common.py
+++ b/workos/types/user_management/authenticate_with_common.py
@@ -51,6 +51,7 @@ class AuthenticateWithRefreshTokenParameters(AuthenticateWithBaseParameters):
     refresh_token: str
     organization_id: Union[str, None]
     grant_type: Literal["refresh_token"]
+    session: Union[SessionConfig, None]
 
 
 AuthenticateWithParameters = Union[

--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -29,6 +29,7 @@ class AuthenticationResponse(_AuthenticationResponseBase):
     impersonator: Optional[Impersonator] = None
     organization_id: Optional[str] = None
     user: User
+    sealed_session: Optional[str] = None
 
 
 class AuthKitAuthenticationResponse(AuthenticationResponse):

--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -39,7 +39,7 @@ class AuthKitAuthenticationResponse(AuthenticationResponse):
     oauth_tokens: Optional[OAuthTokens] = None
 
 
-class RefreshTokenAuthenticationResponse(_AuthenticationResponseBase):
+class RefreshTokenAuthenticationResponse(AuthenticationResponse):
     """Representation of a WorkOS refresh token authentication response."""
 
     pass

--- a/workos/types/user_management/session.py
+++ b/workos/types/user_management/session.py
@@ -1,0 +1,25 @@
+from typing import List, Optional
+from enum import Enum
+
+from workos.types.user_management.impersonator import Impersonator
+from workos.types.user_management.user import User
+from workos.types.workos_model import WorkOSModel
+
+class AuthenticateWithSessionCookieFailureReason(Enum):
+    INVALID_JWT = 'invalid_jwt'
+    INVALID_SESSION_COOKIE = 'invalid_session_cookie'
+    NO_SESSION_COOKIE_PROVIDED = 'no_session_cookie_provided'
+
+class AuthenticateWithSessionCookieSuccessResponse(WorkOSModel):
+    authenticated: bool = True
+    sessionId: str
+    organizationId: Optional[str] = None
+    role: Optional[str] = None
+    permissions: Optional[List[str]] = None
+    user: User
+    impersonator: Optional[Impersonator] = None
+
+class AuthenticateWithSessionCookieErrorResponse(WorkOSModel):
+    authenticated: bool = False
+    reason: AuthenticateWithSessionCookieFailureReason
+

--- a/workos/types/user_management/session.py
+++ b/workos/types/user_management/session.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 from enum import Enum
 
 from workos.types.user_management.impersonator import Impersonator
@@ -23,3 +23,6 @@ class AuthenticateWithSessionCookieErrorResponse(WorkOSModel):
     authenticated: bool = False
     reason: AuthenticateWithSessionCookieFailureReason
 
+class SessionConfig(TypedDict):
+    seal_session: bool
+    cookie_password: str

--- a/workos/types/user_management/session.py
+++ b/workos/types/user_management/session.py
@@ -12,8 +12,8 @@ class AuthenticateWithSessionCookieFailureReason(Enum):
 
 class AuthenticateWithSessionCookieSuccessResponse(WorkOSModel):
     authenticated: bool = True
-    sessionId: str
-    organizationId: Optional[str] = None
+    session_id: str
+    organization_id: Optional[str] = None
     role: Optional[str] = None
     permissions: Optional[List[str]] = None
     user: User

--- a/workos/types/user_management/session.py
+++ b/workos/types/user_management/session.py
@@ -18,6 +18,7 @@ class AuthenticateWithSessionCookieSuccessResponse(WorkOSModel):
     permissions: Optional[List[str]] = None
     user: User
     impersonator: Optional[Impersonator] = None
+    entitlements: Optional[List[str]] = None
 
 class AuthenticateWithSessionCookieErrorResponse(WorkOSModel):
     authenticated: bool = False

--- a/workos/types/user_management/session.py
+++ b/workos/types/user_management/session.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypedDict
+from typing import List, Optional, TypedDict, Union
 from enum import Enum
 
 from workos.types.user_management.impersonator import Impersonator
@@ -22,7 +22,15 @@ class AuthenticateWithSessionCookieSuccessResponse(WorkOSModel):
 
 class AuthenticateWithSessionCookieErrorResponse(WorkOSModel):
     authenticated: bool = False
-    reason: AuthenticateWithSessionCookieFailureReason
+    reason: Union[AuthenticateWithSessionCookieFailureReason, str]
+
+class RefreshWithSessionCookieSuccessResponse(AuthenticateWithSessionCookieSuccessResponse):
+    sealed_session: str
+
+
+class RefreshWithSessionCookieErrorResponse(WorkOSModel):
+    authenticated: bool = False
+    reason: Union[AuthenticateWithSessionCookieFailureReason, str]
 
 class SessionConfig(TypedDict):
     seal_session: bool


### PR DESCRIPTION
## Description
Adds new session helpers. Example API:

```python
# Load session
session = workos.user_management.load_sealed_session(session_data=request.cookies.get('wos_session'), cookie_password=cookie_password)

# Authenticate user
response = session.authenticate()

current_user = response.user if response.authenticated else None

# Refresh session
result = session.refresh()
if result.authenticated == False:
    print("Refresh failed)

# Get log out URL
url = session.get_logout_url()
```

Also makes it so dependencies are loaded from `requirements.txt` rather than hardcoded in `setup.py`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.