### PR TITLE
Add options to Connection resource and add `sso.update_connection()` method

### DIFF
--- a/tests/utils/fixtures/mock_connection.py
+++ b/tests/utils/fixtures/mock_connection.py
@@ -1,5 +1,9 @@
 import datetime
-from workos.types.sso import ConnectionDomain, ConnectionWithDomains
+from workos.types.sso import (
+    ConnectionDomain,
+    ConnectionWithDomains,
+    SamlConnectionOptions,
+)
 
 
 class MockConnection(ConnectionWithDomains):
@@ -14,6 +18,7 @@ class MockConnection(ConnectionWithDomains):
             state="active",
             created_at=now,
             updated_at=now,
+            options=SamlConnectionOptions(signing_cert="signing_cert"),
             domains=[
                 ConnectionDomain(
                     id="connection_domain_abc123",

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -14,6 +14,7 @@ from workos.utils.request_helper import (
     REQUEST_METHOD_POST,
     QueryParameters,
     RequestHelper,
+    REQUEST_METHOD_PUT,
 )
 from workos.types.list_resource import (
     ListArgs,
@@ -167,11 +168,29 @@ class SSOModule(Protocol):
         """
         ...
 
+    def update_connection(
+        self,
+        *,
+        connection_id: str,
+        saml_options_signing_key: Optional[str] = None,
+        saml_options_signing_cert: Optional[str] = None,
+    ) -> SyncOrAsync[None]:
+        """Updates a single connection
+
+        Args:
+            connection_id (str): Connection unique identifier
+            saml_options_signing_key (str): Signing key for the connection (Optional)
+            saml_options_signing_cert (str): Signing certificate for the connection (Optional)
+        Returns:
+            None
+        """
+        ...
+
     def delete_connection(self, connection_id: str) -> SyncOrAsync[None]:
         """Deletes a single Connection
 
         Args:
-            connection (str): Connection unique identifier
+            connection_id (str): Connection unique identifier
 
         Returns:
             None
@@ -255,6 +274,28 @@ class SSO(SSOModule):
             **ListPage[ConnectionWithDomains](**response).model_dump(),
         )
 
+    def update_connection(
+        self,
+        *,
+        connection_id: str,
+        saml_options_signing_key: Optional[str] = None,
+        saml_options_signing_cert: Optional[str] = None,
+    ) -> ConnectionWithDomains:
+        json = {
+            "options": {
+                "signing_key": saml_options_signing_key,
+                "signing_cert": saml_options_signing_cert,
+            }
+        }
+
+        response = self._http_client.request(
+            f"connections/{connection_id}",
+            method=REQUEST_METHOD_PUT,
+            json=json,
+        )
+
+        return ConnectionWithDomains.model_validate(response)
+
     def delete_connection(self, connection_id: str) -> None:
         self._http_client.request(
             f"connections/{connection_id}", method=REQUEST_METHOD_DELETE
@@ -334,6 +375,28 @@ class AsyncSSO(SSOModule):
             list_args=params,
             **ListPage[ConnectionWithDomains](**response).model_dump(),
         )
+
+    async def update_connection(
+        self,
+        *,
+        connection_id: str,
+        saml_options_signing_key: Optional[str] = None,
+        saml_options_signing_cert: Optional[str] = None,
+    ) -> ConnectionWithDomains:
+        json = {
+            "options": {
+                "signing_key": saml_options_signing_key,
+                "signing_cert": saml_options_signing_cert,
+            }
+        }
+
+        response = await self._http_client.request(
+            f"connections/{connection_id}",
+            method=REQUEST_METHOD_PUT,
+            json=json,
+        )
+
+        return ConnectionWithDomains.model_validate(response)
 
     async def delete_connection(self, connection_id: str) -> None:
         await self._http_client.request(

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -174,7 +174,7 @@ class SSOModule(Protocol):
         connection_id: str,
         saml_options_signing_key: Optional[str] = None,
         saml_options_signing_cert: Optional[str] = None,
-    ) -> SyncOrAsync[None]:
+    ) -> SyncOrAsync[ConnectionWithDomains]:
         """Updates a single connection
 
         Args:

--- a/workos/types/sso/connection.py
+++ b/workos/types/sso/connection.py
@@ -45,6 +45,12 @@ ConnectionType = Literal[
 ]
 
 
+class SamlConnectionOptions(WorkOSModel):
+    """Representation of options payload of a Connection Response."""
+
+    signing_cert: Optional[str]
+
+
 class Connection(WorkOSModel):
     object: Literal["connection"]
     id: str
@@ -54,16 +60,10 @@ class Connection(WorkOSModel):
     state: LiteralOrUntyped[ConnectionState]
     created_at: str
     updated_at: str
-
-
-class SamlConnectionOptions(WorkOSModel):
-    """Representation of options payload of a Connection Response."""
-
-    signing_cert: Optional[str]
+    options: Optional[SamlConnectionOptions] = None
 
 
 class ConnectionWithDomains(Connection):
     """Representation of a Connection Response as returned by WorkOS through the SSO feature."""
 
     domains: Sequence[ConnectionDomain]
-    options: Optional[SamlConnectionOptions]

--- a/workos/types/sso/connection.py
+++ b/workos/types/sso/connection.py
@@ -1,4 +1,4 @@
-from typing import Literal, Sequence
+from typing import Literal, Sequence, Optional
 from workos.types.sso.connection_domain import ConnectionDomain
 from workos.types.workos_model import WorkOSModel
 from workos.typing.literals import LiteralOrUntyped
@@ -56,7 +56,14 @@ class Connection(WorkOSModel):
     updated_at: str
 
 
+class SamlConnectionOptions(WorkOSModel):
+    """Representation of options payload of a Connection Response."""
+
+    signing_cert: Optional[str]
+
+
 class ConnectionWithDomains(Connection):
     """Representation of a Connection Response as returned by WorkOS through the SSO feature."""
 
     domains: Sequence[ConnectionDomain]
+    options: Optional[SamlConnectionOptions]


### PR DESCRIPTION
## Description

This PR adds `sso.update_connection()` method which allows to update SAML signing keys.
Contact WorkOS support if you want to enable this feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.