### PR TITLE
Propagate ConflictExceptions properly

### DIFF
--- a/tests/test_async_http_client.py
+++ b/tests/test_async_http_client.py
@@ -5,7 +5,12 @@ import pytest
 from unittest.mock import AsyncMock
 
 from tests.test_sync_http_client import STATUS_CODE_TO_EXCEPTION_MAPPING
-from workos.exceptions import BadRequestException, BaseRequestException, ServerException
+from workos.exceptions import (
+    BadRequestException,
+    BaseRequestException,
+    ConflictException,
+    ServerException,
+)
 from workos.utils.http_client import AsyncHTTPClient
 
 
@@ -186,8 +191,6 @@ class TestAsyncHTTPClient(object):
         except expected_exception as ex:  # type: ignore
             assert ex.message == response_message
             assert ex.request_id == request_id
-        except Exception as ex:
-            # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == expected_exception
 
     async def test_bad_request_exceptions_include_expected_request_data(self):
@@ -210,7 +213,6 @@ class TestAsyncHTTPClient(object):
                 str(ex)
                 == "(message=No message, request_id=request-123, error=example_error, error_description=Example error description)"
             )
-        except Exception as ex:
             assert ex.__class__ == BadRequestException
 
     async def test_bad_request_exceptions_exclude_expected_request_data(self):
@@ -228,7 +230,6 @@ class TestAsyncHTTPClient(object):
             await self.http_client.request("bad_place")
         except BadRequestException as ex:
             assert str(ex) == "(message=No message, request_id=request-123, foo=bar)"
-        except Exception as ex:
             assert ex.__class__ == BadRequestException
 
     async def test_request_bad_body_raises_expected_exception_with_request_data(self):
@@ -247,9 +248,23 @@ class TestAsyncHTTPClient(object):
         except ServerException as ex:
             assert ex.message == None
             assert ex.request_id == request_id
-        except Exception as ex:
-            # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == ServerException
+
+    async def test_conflict_exception(self):
+        request_id = "request-123"
+
+        self.http_client._client.request = AsyncMock(
+            return_value=httpx.Response(
+                status_code=409,
+                headers={"X-Request-ID": request_id},
+            ),
+        )
+
+        try:
+            await self.http_client.request("bad_place")
+        except ConflictException as ex:
+            assert str(ex) == "(message=No message, request_id=request-123)"
+            assert ex.__class__ == ConflictException
 
     async def test_request_includes_base_headers(
         self, capture_and_mock_http_client_request

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -201,8 +201,6 @@ class TestSyncHTTPClient(object):
         except expected_exception as ex:  # type: ignore
             assert ex.message == response_message
             assert ex.request_id == request_id
-        except Exception as ex:
-            # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == expected_exception
 
     def test_bad_request_exceptions_include_request_data(self):
@@ -229,7 +227,6 @@ class TestSyncHTTPClient(object):
                 str(ex)
                 == "(message=No message, request_id=request-123, error=example_error, error_description=Example error description, foo=bar)"
             )
-        except Exception as ex:
             assert ex.__class__ == BadRequestException
 
     def test_request_bad_body_raises_expected_exception_with_request_data(self):
@@ -248,8 +245,6 @@ class TestSyncHTTPClient(object):
         except ServerException as ex:
             assert ex.message == None
             assert ex.request_id == request_id
-        except Exception as ex:
-            # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == ServerException
 
     def test_conflict_exception(self):
@@ -266,7 +261,6 @@ class TestSyncHTTPClient(object):
             self.http_client.request("bad_place")
         except ConflictException as ex:
             assert str(ex) == "(message=No message, request_id=request-123)"
-        except Exception as ex:
             assert ex.__class__ == ConflictException
 
     def test_request_includes_base_headers(self, capture_and_mock_http_client_request):

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -9,6 +9,7 @@ from workos.exceptions import (
     AuthorizationException,
     BadRequestException,
     BaseRequestException,
+    ConflictException,
     ServerException,
 )
 from workos.utils.http_client import SyncHTTPClient
@@ -250,6 +251,23 @@ class TestSyncHTTPClient(object):
         except Exception as ex:
             # This'll fail for sure here but... just using the nice error that'd come up
             assert ex.__class__ == ServerException
+
+    def test_conflict_exception(self):
+        request_id = "request-123"
+
+        self.http_client._client.request = MagicMock(
+            return_value=httpx.Response(
+                status_code=409,
+                headers={"X-Request-ID": request_id},
+            ),
+        )
+
+        try:
+            self.http_client.request("bad_place")
+        except ConflictException as ex:
+            assert str(ex) == "(message=No message, request_id=request-123)"
+        except Exception as ex:
+            assert ex.__class__ == ConflictException
 
     def test_request_includes_base_headers(self, capture_and_mock_http_client_request):
         request_kwargs = capture_and_mock_http_client_request(self.http_client, {}, 200)

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -53,6 +53,10 @@ class BadRequestException(BaseRequestException):
     pass
 
 
+class ConflictException(BaseRequestException):
+    pass
+
+
 class NotFoundException(BaseRequestException):
     pass
 

--- a/workos/utils/_base_http_client.py
+++ b/workos/utils/_base_http_client.py
@@ -16,6 +16,7 @@ import httpx
 from httpx._types import QueryParamTypes
 
 from workos.exceptions import (
+    ConflictException,
     ServerException,
     AuthenticationException,
     AuthorizationException,
@@ -101,6 +102,8 @@ class BaseHTTPClient(Generic[_HttpxClientT]):
                 raise AuthorizationException(response, response_json)
             elif status_code == 404:
                 raise NotFoundException(response, response_json)
+            elif status_code == 409:
+                raise ConflictException(response, response_json)
 
             raise BadRequestException(response, response_json)
         elif status_code >= 500 and status_code < 600:


### PR DESCRIPTION
## Description
Propagate ConflictExceptions properly and don't mask them as BadRequestExceptions.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.