### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/tests/utils/fixtures/mock_role.py
+++ b/tests/utils/fixtures/mock_role.py
@@ -1,9 +1,9 @@
 import datetime
 
-from workos.types.roles.role import OrganizationRole
+from workos.types.roles.role import Role
 
 
-class MockRole(OrganizationRole):
+class MockRole(Role):
     def __init__(self, id):
         now = datetime.datetime.now().isoformat()
         super().__init__(

--- a/tests/utils/fixtures/mock_role.py
+++ b/tests/utils/fixtures/mock_role.py
@@ -1,0 +1,18 @@
+import datetime
+
+from workos.types.roles.role import OrganizationRole
+
+
+class MockRole(OrganizationRole):
+    def __init__(self, id):
+        now = datetime.datetime.now().isoformat()
+        super().__init__(
+            object="role",
+            id=id,
+            name="Member",
+            slug="member",
+            description="The default member role",
+            type="EnvironmentRole",
+            created_at=now,
+            updated_at=now,
+        )

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -2,7 +2,7 @@ from typing import Optional, Protocol, Sequence
 
 from workos.types.organizations.domain_data_input import DomainDataInput
 from workos.types.organizations.list_filters import OrganizationListFilters
-from workos.types.roles.role import OrganizationRole, RolesList
+from workos.types.roles.role import RoleList
 from workos.typing.sync_or_async import SyncOrAsync
 from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
 from workos.utils.pagination_order import PaginationOrder
@@ -224,13 +224,13 @@ class Organizations(OrganizationsModule):
             method=REQUEST_METHOD_DELETE,
         )
 
-    def list_organization_roles(self, organization_id: str) -> RolesList:
+    def list_organization_roles(self, organization_id: str) -> RoleList:
         response = self._http_client.request(
             f"organizations/{organization_id}/roles",
             method=REQUEST_METHOD_GET,
         )
 
-        return RolesList.model_validate(response)
+        return RoleList.model_validate(response)
 
 
 class AsyncOrganizations(OrganizationsModule):
@@ -334,10 +334,10 @@ class AsyncOrganizations(OrganizationsModule):
             method=REQUEST_METHOD_DELETE,
         )
 
-    async def list_organization_roles(self, organization_id: str) -> RolesList:
+    async def list_organization_roles(self, organization_id: str) -> RoleList:
         response = await self._http_client.request(
             f"organizations/{organization_id}/roles",
             method=REQUEST_METHOD_GET,
         )
 
-        return RolesList.model_validate(response)
+        return RoleList.model_validate(response)

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -2,6 +2,7 @@ from typing import Optional, Protocol, Sequence
 
 from workos.types.organizations.domain_data_input import DomainDataInput
 from workos.types.organizations.list_filters import OrganizationListFilters
+from workos.types.roles.role import OrganizationRole, RolesList
 from workos.typing.sync_or_async import SyncOrAsync
 from workos.utils.http_client import AsyncHTTPClient, SyncHTTPClient
 from workos.utils.pagination_order import PaginationOrder
@@ -223,6 +224,14 @@ class Organizations(OrganizationsModule):
             method=REQUEST_METHOD_DELETE,
         )
 
+    def list_organization_roles(self, organization_id: str) -> RolesList:
+        response = self._http_client.request(
+            f"organizations/{organization_id}/roles",
+            method=REQUEST_METHOD_GET,
+        )
+
+        return RolesList.model_validate(response)
+
 
 class AsyncOrganizations(OrganizationsModule):
 
@@ -324,3 +333,11 @@ class AsyncOrganizations(OrganizationsModule):
             f"organizations/{organization_id}",
             method=REQUEST_METHOD_DELETE,
         )
+
+    async def list_organization_roles(self, organization_id: str) -> RolesList:
+        response = await self._http_client.request(
+            f"organizations/{organization_id}/roles",
+            method=REQUEST_METHOD_GET,
+        )
+
+        return RolesList.model_validate(response)

--- a/workos/types/events/event.py
+++ b/workos/types/events/event.py
@@ -27,7 +27,6 @@ from workos.types.events.directory_group_with_previous_attributes import (
 )
 from workos.types.events.directory_payload import DirectoryPayload
 from workos.types.events.directory_payload_with_legacy_fields import (
-    DirectoryPayloadWithLegacyFields,
     DirectoryPayloadWithLegacyFieldsForEventsApi,
 )
 from workos.types.events.directory_user_with_previous_attributes import (
@@ -40,7 +39,7 @@ from workos.types.events.organization_domain_verification_failed_payload import 
 from workos.types.events.session_created_payload import SessionCreatedPayload
 from workos.types.organizations.organization_common import OrganizationCommon
 from workos.types.organizations.organization_domain import OrganizationDomain
-from workos.types.roles.role import Role
+from workos.types.roles.role import EventRole
 from workos.types.sso.connection import Connection
 from workos.types.user_management.email_verification import (
     EmailVerificationCommon,
@@ -210,15 +209,15 @@ class PasswordResetCreatedEvent(EventModel[PasswordResetCommon]):
     event: Literal["password_reset.created"]
 
 
-class RoleCreatedEvent(EventModel[Role]):
+class RoleCreatedEvent(EventModel[EventRole]):
     event: Literal["role.created"]
 
 
-class RoleDeletedEvent(EventModel[Role]):
+class RoleDeletedEvent(EventModel[EventRole]):
     event: Literal["role.deleted"]
 
 
-class RoleUpdatedEvent(EventModel[Role]):
+class RoleUpdatedEvent(EventModel[EventRole]):
     event: Literal["role.updated"]
 
 

--- a/workos/types/events/event_model.py
+++ b/workos/types/events/event_model.py
@@ -38,7 +38,7 @@ from workos.types.events.organization_domain_verification_failed_payload import 
 from workos.types.events.session_created_payload import SessionCreatedPayload
 from workos.types.organizations.organization_common import OrganizationCommon
 from workos.types.organizations.organization_domain import OrganizationDomain
-from workos.types.roles.role import Role
+from workos.types.roles.role import EventRole
 from workos.types.sso.connection import Connection
 from workos.types.user_management.email_verification import (
     EmailVerificationCommon,
@@ -72,6 +72,7 @@ EventPayload = TypeVar(
     DirectoryUserWithPreviousAttributes,
     DirectoryGroupMembershipPayload,
     EmailVerificationCommon,
+    EventRole,
     InvitationCommon,
     MagicAuthCommon,
     OrganizationCommon,
@@ -79,7 +80,6 @@ EventPayload = TypeVar(
     OrganizationDomainVerificationFailedPayload,
     OrganizationMembership,
     PasswordResetCommon,
-    Role,
     SessionCreatedPayload,
     User,
 )

--- a/workos/types/roles/role.py
+++ b/workos/types/roles/role.py
@@ -1,8 +1,28 @@
 from typing import Literal, Optional, Sequence
 from workos.types.workos_model import WorkOSModel
 
+RoleType = Literal["EnvironmentRole", "OrganizationRole"]
 
-class Role(WorkOSModel):
+
+class RoleCommon(WorkOSModel):
     object: Literal["role"]
     slug: str
+
+
+# TODO: This is used for events/webhooks only. Rename to EventRole or something similar.
+class Role(RoleCommon):
     permissions: Optional[Sequence[str]] = None
+
+
+class OrganizationRole(RoleCommon):
+    id: str
+    name: str
+    description: Optional[str] = None
+    type: RoleType
+    created_at: str
+    updated_at: str
+
+
+class RolesList(WorkOSModel):
+    object: Literal["list"]
+    data: Sequence[OrganizationRole]

--- a/workos/types/roles/role.py
+++ b/workos/types/roles/role.py
@@ -9,12 +9,11 @@ class RoleCommon(WorkOSModel):
     slug: str
 
 
-# TODO: This is used for events/webhooks only. Rename to EventRole or something similar.
-class Role(RoleCommon):
+class EventRole(RoleCommon):
     permissions: Optional[Sequence[str]] = None
 
 
-class OrganizationRole(RoleCommon):
+class Role(RoleCommon):
     id: str
     name: str
     description: Optional[str] = None
@@ -23,6 +22,6 @@ class OrganizationRole(RoleCommon):
     updated_at: str
 
 
-class RolesList(WorkOSModel):
+class RoleList(WorkOSModel):
     object: Literal["list"]
-    data: Sequence[OrganizationRole]
+    data: Sequence[Role]

--- a/workos/types/webhooks/webhook.py
+++ b/workos/types/webhooks/webhook.py
@@ -39,7 +39,7 @@ from workos.types.events.organization_domain_verification_failed_payload import 
 from workos.types.events.session_created_payload import SessionCreatedPayload
 from workos.types.organizations.organization_common import OrganizationCommon
 from workos.types.organizations.organization_domain import OrganizationDomain
-from workos.types.roles.role import Role
+from workos.types.roles.role import EventRole
 from workos.types.sso.connection import Connection
 from workos.types.user_management.email_verification import (
     EmailVerificationCommon,
@@ -213,15 +213,15 @@ class PasswordResetCreatedWebhook(WebhookModel[PasswordResetCommon]):
     event: Literal["password_reset.created"]
 
 
-class RoleCreatedWebhook(WebhookModel[Role]):
+class RoleCreatedWebhook(WebhookModel[EventRole]):
     event: Literal["role.created"]
 
 
-class RoleDeletedWebhook(WebhookModel[Role]):
+class RoleDeletedWebhook(WebhookModel[EventRole]):
     event: Literal["role.deleted"]
 
 
-class RoleUpdatedWebhook(WebhookModel[Role]):
+class RoleUpdatedWebhook(WebhookModel[EventRole]):
     event: Literal["role.updated"]
 
 


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.