### PR TITLE
Don't overwrite default transport so proxies can be set via environment variables

### DIFF
--- a/workos/utils/http_client.py
+++ b/workos/utils/http_client.py
@@ -38,7 +38,7 @@ class SyncHTTPClient(BaseHTTPClient[httpx.Client]):
         client_id: str,
         version: str,
         timeout: Optional[int] = None,
-        transport: Optional[httpx.BaseTransport] = httpx.HTTPTransport(),
+        transport: Optional[httpx.BaseTransport] = None,
     ) -> None:
         super().__init__(
             api_key=api_key,
@@ -51,7 +51,9 @@ class SyncHTTPClient(BaseHTTPClient[httpx.Client]):
             base_url=base_url,
             timeout=timeout,
             follow_redirects=True,
-            transport=transport,
+            # Only pass the transport if a custom one is provided, otherwise let httpx use
+            # the default so we don't overwrite environment configurations like proxies
+            transport=transport if transport else None,
         )
 
     def is_closed(self) -> bool:
@@ -136,7 +138,7 @@ class AsyncHTTPClient(BaseHTTPClient[httpx.AsyncClient]):
         client_id: str,
         version: str,
         timeout: Optional[int] = None,
-        transport: Optional[httpx.AsyncBaseTransport] = httpx.AsyncHTTPTransport(),
+        transport: Optional[httpx.AsyncBaseTransport] = None,
     ) -> None:
         super().__init__(
             base_url=base_url,
@@ -149,7 +151,9 @@ class AsyncHTTPClient(BaseHTTPClient[httpx.AsyncClient]):
             base_url=base_url,
             timeout=timeout,
             follow_redirects=True,
-            transport=transport,
+            # Only pass the transport if a custom one is provided, otherwise let httpx use
+            # the default so we don't overwrite environment configurations like proxies
+            transport=transport if transport else None,
         )
 
     def is_closed(self) -> bool:

--- a/workos/utils/http_client.py
+++ b/workos/utils/http_client.py
@@ -38,6 +38,8 @@ class SyncHTTPClient(BaseHTTPClient[httpx.Client]):
         client_id: str,
         version: str,
         timeout: Optional[int] = None,
+        # If no custom transport is provided, let httpx use the default
+        # so we don't overwrite environment configurations like proxies
         transport: Optional[httpx.BaseTransport] = None,
     ) -> None:
         super().__init__(
@@ -51,9 +53,7 @@ class SyncHTTPClient(BaseHTTPClient[httpx.Client]):
             base_url=base_url,
             timeout=timeout,
             follow_redirects=True,
-            # Only pass the transport if a custom one is provided, otherwise let httpx use
-            # the default so we don't overwrite environment configurations like proxies
-            transport=transport if transport else None,
+            transport=transport,
         )
 
     def is_closed(self) -> bool:
@@ -138,6 +138,8 @@ class AsyncHTTPClient(BaseHTTPClient[httpx.AsyncClient]):
         client_id: str,
         version: str,
         timeout: Optional[int] = None,
+        # If no custom transport is provided, let httpx use the default
+        # so we don't overwrite environment configurations like proxies
         transport: Optional[httpx.AsyncBaseTransport] = None,
     ) -> None:
         super().__init__(
@@ -151,9 +153,7 @@ class AsyncHTTPClient(BaseHTTPClient[httpx.AsyncClient]):
             base_url=base_url,
             timeout=timeout,
             follow_redirects=True,
-            # Only pass the transport if a custom one is provided, otherwise let httpx use
-            # the default so we don't overwrite environment configurations like proxies
-            transport=transport if transport else None,
+            transport=transport,
         )
 
     def is_closed(self) -> bool:


### PR DESCRIPTION
## Description
Don't overwrite default transport, so proxies can be set via environment variables. Tested and confirmed requests work as usual with no proxy, and are proxies properly when setting HTTPS_PROXY and ALL_PROXY environment variables.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.