### PR TITLE
Add `return_to` parameter to `get_logout_url`

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -362,6 +362,14 @@ class TestUserManagementBase(UserManagementFixtures):
 
         assert expected == result
 
+    def test_get_logout_url_with_return_to(self):
+        expected = "https://api.workos.test/user_management/sessions/logout?session_id=session_123&return_to=https%3A%2F%2Fexample.com%2Fsigned-out"
+        result = self.user_management.get_logout_url(
+            "session_123", return_to="https://example.com/signed-out"
+        )
+
+        assert expected == result
+
 
 @pytest.mark.sync_and_async(UserManagement, AsyncUserManagement)
 class TestUserManagement(UserManagementFixtures):

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -1,4 +1,5 @@
 from typing import Optional, Protocol, Sequence, Type, cast
+from urllib.parse import urlencode
 from workos._client_configuration import ClientConfiguration
 from workos.session import Session
 from workos.types.list_resource import (
@@ -588,19 +589,25 @@ class UserManagementModule(Protocol):
 
         return f"{self._client_configuration.base_url}sso/jwks/{self._client_configuration.client_id}"
 
-    def get_logout_url(self, session_id: str) -> str:
+    def get_logout_url(self, session_id: str, return_to: Optional[str] = None) -> str:
         """Get the URL for ending the session and redirecting the user
 
         This method is purposefully designed as synchronous as it does not make any HTTP requests.
 
         Args:
             session_id (str): The ID of the user's session
+            return_to (str): The URL to redirect the user to after the session is ended. (Optional)
 
         Returns:
             (str): URL to redirect the user to to end the session.
         """
 
-        return f"{self._client_configuration.base_url}user_management/sessions/logout?session_id={session_id}"
+        params = {"session_id": session_id}
+
+        if return_to:
+            params["return_to"] = return_to
+
+        return f"{self._client_configuration.base_url}user_management/sessions/logout?{urlencode(params)}"
 
     def get_password_reset(self, password_reset_id: str) -> SyncOrAsync[PasswordReset]:
         """Get the details of a password reset object.


### PR DESCRIPTION
## Description

Adds a new optional `return_to` parameter to `user_management.get_logout_url` to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.