### PR TITLE
adding strip_customer_id to python sdk to support entitlements

### DIFF
--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -105,6 +105,7 @@ class OrganizationsModule(Protocol):
             organization (str): Organization's unique identifier.
             name (str): A descriptive name for the organization. (Optional)
             domain_data (Sequence[DomainDataInput]): List of domains that belong to the organization. (Optional)
+            stripe_customer_id (str): The ID of the Stripe customer associated with the organization. (Optional)
 
         Returns:
             Organization: Updated Organization response from WorkOS.
@@ -206,10 +207,12 @@ class Organizations(OrganizationsModule):
         organization_id: str,
         name: Optional[str] = None,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
+        stripe_customer_id: Optional[str] = None,
     ) -> Organization:
         json = {
             "name": name,
             "domain_data": domain_data,
+            "stripe_customer_id": stripe_customer_id,
         }
 
         response = self._http_client.request(
@@ -316,10 +319,12 @@ class AsyncOrganizations(OrganizationsModule):
         organization_id: str,
         name: Optional[str] = None,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
+        stripe_customer_id: Optional[str] = None,
     ) -> Organization:
         json = {
             "name": name,
             "domain_data": domain_data,
+            "stripe_customer_id": stripe_customer_id,
         }
 
         response = await self._http_client.request(

--- a/workos/types/organizations/organization.py
+++ b/workos/types/organizations/organization.py
@@ -7,3 +7,4 @@ class Organization(OrganizationCommon):
     allow_profiles_outside_organization: bool
     domains: Sequence[OrganizationDomain]
     lookup_key: Optional[str] = None
+    stripe_customer_id: Optional[str] = None


### PR DESCRIPTION
## Description

Python SDK `update_organization` was missing the parameter `stripe_customer_id` 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.