### PR TITLE
Adjust version pinning to allow for more cryptography versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ httpx~=0.28.1
 pydantic~=2.10.4
 PyJWT>=2.9.0, <2.10 ; python_version == "3.8"
 PyJWT>=2.10.0; python_version > "3.8"
-cryptography>=42.0.4, <45
+cryptography>=42.0.8, <45

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 httpx~=0.28.1
 pydantic~=2.10.4
-PyJWT==2.9.0 # Pinned because of Python 3.8 incompatibility in future versions
-cryptography~=44.0.0
+PyJWT>=2.9.0, <2.10 ; python_version == "3.8"
+PyJWT>=2.10.0; python_version > "3.8"
+cryptography>=42.0.4, <45

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=read_requirements("requirements.txt"),
     extras_require={
         "dev": read_requirements("requirements-dev.txt"),
-        ":python_version<'3.4'": ["enum34"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Description
Adjust version pinning to allow for more cryptography versions. Opened up to 42.0.8, which had a CVE fix.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.