### PR TITLE
Add `intent_options` parameter on `Portal.generate_link()` method

### DIFF
--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -13,13 +13,26 @@ class TestPortal(object):
     def mock_portal_link(self):
         return {"link": "https://id.workos.com/portal/launch?secret=secret"}
 
-    def test_generate_link_sso(self, mock_portal_link, mock_http_client_with_response):
-        mock_http_client_with_response(self.http_client, mock_portal_link, 201)
-
-        response = self.portal.generate_link(
-            intent="sso", organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3"
+    def test_generate_link_sso(
+        self, mock_portal_link, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_portal_link, 201
         )
 
+        response = self.portal.generate_link(
+            intent="sso",
+            organization_id="org_01EHQMYV6MBK39QC5PZXHY59C3",
+            intent_options={"sso": {"bookmark_slug": "my_app"}},
+        )
+
+        assert request_kwargs["url"].endswith("/portal/generate_link")
+        assert request_kwargs["method"] == "post"
+        assert request_kwargs["json"] == {
+            "intent": "sso",
+            "organization": "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "intent_options": {"sso": {"bookmark_slug": "my_app"}},
+        }
         assert response.link == "https://id.workos.com/portal/launch?secret=secret"
 
     def test_generate_link_domain_verification(

--- a/workos/portal.py
+++ b/workos/portal.py
@@ -1,6 +1,7 @@
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Dict, Literal, Union
 from workos.types.portal.portal_link import PortalLink
 from workos.types.portal.portal_link_intent import PortalLinkIntent
+from workos.types.portal.portal_link_intent_options import IntentOptions
 from workos.utils.http_client import SyncHTTPClient
 from workos.utils.request_helper import REQUEST_METHOD_POST
 
@@ -16,6 +17,7 @@ class PortalModule(Protocol):
         organization_id: str,
         return_url: Optional[str] = None,
         success_url: Optional[str] = None,
+        intent_options: Optional[IntentOptions] = None,
     ) -> PortalLink:
         """Generate a link to grant access to an organization's Admin Portal
 
@@ -47,13 +49,16 @@ class Portal(PortalModule):
         organization_id: str,
         return_url: Optional[str] = None,
         success_url: Optional[str] = None,
+        intent_options: Optional[IntentOptions] = None,
     ) -> PortalLink:
         json = {
             "intent": intent,
             "organization": organization_id,
             "return_url": return_url,
             "success_url": success_url,
+            "intent_options": intent_options,
         }
+
         response = self._http_client.request(
             PORTAL_GENERATE_PATH, method=REQUEST_METHOD_POST, json=json
         )

--- a/workos/types/portal/portal_link_intent_options.py
+++ b/workos/types/portal/portal_link_intent_options.py
@@ -1,0 +1,9 @@
+from typing import TypedDict
+
+
+class SsoIntentOptions(TypedDict):
+    bookmark_slug: str
+
+
+class IntentOptions(TypedDict):
+    sso: SsoIntentOptions


### PR DESCRIPTION
## Description

This PR introduces the `intent_options` parameter in the `Portal.generate_link()` method. This feature is not generally available on WorkOS API. Contact WorkOS support for access.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.