### PR TITLE
add last_sign_in_at to user

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -390,6 +390,7 @@ class TestUserManagement(UserManagementFixtures):
         assert request_kwargs["method"] == "get"
         assert user.id == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
         assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
+        assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
 
     def test_list_users_auto_pagination(
         self,

--- a/tests/utils/fixtures/mock_user.py
+++ b/tests/utils/fixtures/mock_user.py
@@ -14,6 +14,7 @@ class MockUser(User):
             last_name="Hoeger",
             email_verified=False,
             profile_picture_url="https://example.com/profile-picture.jpg",
+            last_sign_in_at="2021-06-25T19:07:33.155Z",
             created_at=now,
             updated_at=now,
         )

--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -12,5 +12,6 @@ class User(WorkOSModel):
     last_name: Optional[str] = None
     email_verified: bool
     profile_picture_url: Optional[str] = None
+    last_sign_in_at: Optional[str] = None
     created_at: str
     updated_at: str


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4178/update-workos-python-sdk-for-last-sign-in-at

adds `last_sign_in_at` to user
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

docs PR: https://github.com/workos/workos/pull/35170
