### PR TITLE
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

### DIFF
--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -69,6 +69,7 @@ class TestDirectorySync:
             "organization_id": "org_01EZTR6WYX1A0DSE2CYMGXQ24Y",
             "first_name": "Marcelina",
             "last_name": "Davis",
+            "email": None,
             "job_title": "Software Engineer",
             "emails": [],
             "username": "marcelina@foo-corp.com",

--- a/tests/utils/fixtures/mock_directory_user.py
+++ b/tests/utils/fixtures/mock_directory_user.py
@@ -16,6 +16,7 @@ class MockDirectoryUser(DirectoryUserWithGroups):
             first_name="gsuite_directory",
             last_name="fried chicken",
             job_title="developer",
+            email="marcelina@foo-corp.com",
             emails=[
                 DirectoryUserEmail(
                     primary=True, type="work", value="marcelina@foo-corp.com"

--- a/workos/types/directory_sync/directory_user.py
+++ b/workos/types/directory_sync/directory_user.py
@@ -25,8 +25,12 @@ class DirectoryUser(WorkOSModel):
     organization_id: str
     first_name: Optional[str] = None
     last_name: Optional[str] = None
+    email: Optional[str] = None
+    # @deprecated Will be removed in a future major version. Enable the `job_title` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
     job_title: Optional[str] = None
+    # @deprecated Will be removed in a future major version. Enable the `emails` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
     emails: Sequence[DirectoryUserEmail]
+    # @deprecated Will be removed in a future major version. Enable the `username` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
     username: Optional[str] = None
     state: DirectoryUserState
     custom_attributes: Dict[str, Any]


### PR DESCRIPTION
## Description
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.