### PR TITLE
Add missing list of workos module public symbols

### DIFF
--- a/workos/__init__.py
+++ b/workos/__init__.py
@@ -1,2 +1,4 @@
 from workos.client import SyncClient as WorkOSClient
 from workos.async_client import AsyncClient as AsyncWorkOSClient
+
+__all__ = ["WorkOSClient", "AsyncWorkOSClient"]


### PR DESCRIPTION
## Description
Add missing list of workos module public symbols.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.