### PR TITLE
Add external_id to user and organization

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -109,7 +109,7 @@ class TestOrganizations:
         assert request_kwargs["method"] == "get"
         assert request_kwargs["url"].endswith("/organizations/organization_id")
 
-    def test_get_organization_by_lookup_key(
+    def test_get_organization_by_external_id(
         self, mock_organization, capture_and_mock_http_client_request
     ):
         request_kwargs = capture_and_mock_http_client_request(
@@ -117,12 +117,12 @@ class TestOrganizations:
         )
 
         organization = syncify(
-            self.organizations.get_organization_by_lookup_key(lookup_key="test")
+            self.organizations.get_organization_by_external_id(external_id="test")
         )
 
         assert organization.dict() == mock_organization
         assert request_kwargs["method"] == "get"
-        assert request_kwargs["url"].endswith("/organizations/by_lookup_key/test")
+        assert request_kwargs["url"].endswith("/organizations/external_id/test")
 
     def test_create_organization_with_domain_data(
         self, mock_organization, capture_and_mock_http_client_request

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -392,6 +392,26 @@ class TestUserManagement(UserManagementFixtures):
         assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
         assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
 
+    def test_get_user_by_external_id(
+        self, mock_user, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_user, 200
+        )
+
+        external_id = "external-id"
+        user = syncify(
+            self.user_management.get_user_by_external_id(external_id=external_id)
+        )
+
+        assert request_kwargs["url"].endswith(
+            f"user_management/users/external_id/{external_id}"
+        )
+        assert request_kwargs["method"] == "get"
+        assert user.id == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
+        assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
+        assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
+
     def test_list_users_auto_pagination(
         self,
         mock_users_multiple_pages,

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -60,13 +60,13 @@ class OrganizationsModule(Protocol):
         """
         ...
 
-    def get_organization_by_lookup_key(
-        self, lookup_key: str
+    def get_organization_by_external_id(
+        self, external_id: str
     ) -> SyncOrAsync[Organization]:
-        """Gets details for a single Organization by lookup key
+        """Gets details for a single Organization by external id
 
         Args:
-            lookup_key (str): Organization's lookup key
+            external_id (str): Organization's external id
 
         Returns:
             Organization: Organization response from WorkOS
@@ -125,7 +125,6 @@ class OrganizationsModule(Protocol):
 
 
 class Organizations(OrganizationsModule):
-
     _http_client: SyncHTTPClient
 
     def __init__(self, http_client: SyncHTTPClient):
@@ -167,9 +166,9 @@ class Organizations(OrganizationsModule):
 
         return Organization.model_validate(response)
 
-    def get_organization_by_lookup_key(self, lookup_key: str) -> Organization:
+    def get_organization_by_external_id(self, external_id: str) -> Organization:
         response = self._http_client.request(
-            "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
+            "organizations/external_id/{external_id}".format(external_id=external_id),
             method=REQUEST_METHOD_GET,
         )
 
@@ -237,7 +236,6 @@ class Organizations(OrganizationsModule):
 
 
 class AsyncOrganizations(OrganizationsModule):
-
     _http_client: AsyncHTTPClient
 
     def __init__(self, http_client: AsyncHTTPClient):
@@ -279,9 +277,9 @@ class AsyncOrganizations(OrganizationsModule):
 
         return Organization.model_validate(response)
 
-    async def get_organization_by_lookup_key(self, lookup_key: str) -> Organization:
+    async def get_organization_by_external_id(self, external_id: str) -> Organization:
         response = await self._http_client.request(
-            "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
+            "organizations/external_id/{external_id}".format(external_id=external_id),
             method=REQUEST_METHOD_GET,
         )
 

--- a/workos/types/organizations/organization.py
+++ b/workos/types/organizations/organization.py
@@ -6,5 +6,5 @@ from workos.types.organizations.organization_domain import OrganizationDomain
 class Organization(OrganizationCommon):
     allow_profiles_outside_organization: bool
     domains: Sequence[OrganizationDomain]
-    lookup_key: Optional[str] = None
     stripe_customer_id: Optional[str] = None
+    external_id: Optional[str] = None

--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -15,3 +15,4 @@ class User(WorkOSModel):
     last_sign_in_at: Optional[str] = None
     created_at: str
     updated_at: str
+    external_id: Optional[str] = None

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -66,6 +66,7 @@ from workos.utils.request_helper import (
 
 USER_PATH = "user_management/users"
 USER_DETAIL_PATH = "user_management/users/{0}"
+USER_DETAIL_BY_EXTERNAL_ID_PATH = "user_management/users/external_id/{0}"
 ORGANIZATION_MEMBERSHIP_PATH = "user_management/organization_memberships"
 ORGANIZATION_MEMBERSHIP_DETAIL_PATH = "user_management/organization_memberships/{0}"
 ORGANIZATION_MEMBERSHIP_DEACTIVATE_PATH = (
@@ -132,6 +133,16 @@ class UserManagementModule(Protocol):
 
         Args:
             user_id (str): User unique identifier
+        Returns:
+            User: User response from WorkOS.
+        """
+        ...
+
+    def get_user_by_external_id(self, external_id: str) -> SyncOrAsync[User]:
+        """Get the details of an existing user.
+
+        Args:
+            external_id (str): The user's external id
         Returns:
             User: User response from WorkOS.
         """
@@ -389,7 +400,6 @@ class UserManagementModule(Protocol):
             )
 
         if connection_id is not None:
-
             params["connection_id"] = connection_id
         if organization_id is not None:
             params["organization_id"] = organization_id
@@ -856,6 +866,14 @@ class UserManagement(UserManagementModule):
     def get_user(self, user_id: str) -> User:
         response = self._http_client.request(
             USER_DETAIL_PATH.format(user_id), method=REQUEST_METHOD_GET
+        )
+
+        return User.model_validate(response)
+
+    def get_user_by_external_id(self, external_id: str) -> User:
+        response = self._http_client.request(
+            USER_DETAIL_BY_EXTERNAL_ID_PATH.format(external_id),
+            method=REQUEST_METHOD_GET,
         )
 
         return User.model_validate(response)
@@ -1460,6 +1478,14 @@ class AsyncUserManagement(UserManagementModule):
     async def get_user(self, user_id: str) -> User:
         response = await self._http_client.request(
             USER_DETAIL_PATH.format(user_id), method=REQUEST_METHOD_GET
+        )
+
+        return User.model_validate(response)
+
+    async def get_user_by_external_id(self, external_id: str) -> User:
+        response = await self._http_client.request(
+            USER_DETAIL_BY_EXTERNAL_ID_PATH.format(external_id),
+            method=REQUEST_METHOD_GET,
         )
 
         return User.model_validate(response)


### PR DESCRIPTION
## Description

Add a method to get users by external id.

Change organization get by lookup key which no longer works to be get by external id.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.