### PR TITLE
Add metadata and external id to users and organizations

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -109,7 +109,7 @@ class TestOrganizations:
         assert request_kwargs["method"] == "get"
         assert request_kwargs["url"].endswith("/organizations/organization_id")
 
-    def test_get_organization_by_lookup_key(
+    def test_get_organization_by_external_id(
         self, mock_organization, capture_and_mock_http_client_request
     ):
         request_kwargs = capture_and_mock_http_client_request(
@@ -117,12 +117,12 @@ class TestOrganizations:
         )
 
         organization = syncify(
-            self.organizations.get_organization_by_lookup_key(lookup_key="test")
+            self.organizations.get_organization_by_external_id(external_id="test")
         )
 
         assert organization.dict() == mock_organization
         assert request_kwargs["method"] == "get"
-        assert request_kwargs["url"].endswith("/organizations/by_lookup_key/test")
+        assert request_kwargs["url"].endswith("/organizations/external_id/test")
 
     def test_create_organization_with_domain_data(
         self, mock_organization, capture_and_mock_http_client_request

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -411,6 +411,7 @@ class TestUserManagement(UserManagementFixtures):
         assert user.id == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
         assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
         assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
+        assert user.metadata == mock_user["metadata"]
 
     def test_list_users_auto_pagination(
         self,

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -392,6 +392,26 @@ class TestUserManagement(UserManagementFixtures):
         assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
         assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
 
+    def test_get_user_by_external_id(
+        self, mock_user, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_user, 200
+        )
+
+        external_id = "external-id"
+        user = syncify(
+            self.user_management.get_user_by_external_id(external_id=external_id)
+        )
+
+        assert request_kwargs["url"].endswith(
+            f"user_management/users/external_id/{external_id}"
+        )
+        assert request_kwargs["method"] == "get"
+        assert user.id == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
+        assert user.profile_picture_url == "https://example.com/profile-picture.jpg"
+        assert user.last_sign_in_at == "2021-06-25T19:07:33.155Z"
+
     def test_list_users_auto_pagination(
         self,
         mock_users_multiple_pages,

--- a/tests/utils/fixtures/mock_organization.py
+++ b/tests/utils/fixtures/mock_organization.py
@@ -22,4 +22,5 @@ class MockOrganization(Organization):
                     domain="example.io",
                 )
             ],
+            metadata={"key": "value"},
         )

--- a/tests/utils/fixtures/mock_user.py
+++ b/tests/utils/fixtures/mock_user.py
@@ -17,4 +17,5 @@ class MockUser(User):
             last_sign_in_at="2021-06-25T19:07:33.155Z",
             created_at=now,
             updated_at=now,
+            metadata={"key": "value"},
         )

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -1,5 +1,6 @@
 from typing import Optional, Protocol, Sequence
 
+from workos.types.metadata import Metadata
 from workos.types.organizations.domain_data_input import DomainDataInput
 from workos.types.organizations.list_filters import OrganizationListFilters
 from workos.types.roles.role import RoleList
@@ -79,6 +80,8 @@ class OrganizationsModule(Protocol):
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         idempotency_key: Optional[str] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> SyncOrAsync[Organization]:
         """Create an organization
 
@@ -98,6 +101,8 @@ class OrganizationsModule(Protocol):
         organization_id: str,
         name: Optional[str] = None,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> SyncOrAsync[Organization]:
         """Update an organization
 
@@ -180,6 +185,8 @@ class Organizations(OrganizationsModule):
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         idempotency_key: Optional[str] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> Organization:
         headers = {}
         if idempotency_key:
@@ -189,6 +196,8 @@ class Organizations(OrganizationsModule):
             "name": name,
             "domain_data": domain_data,
             "idempotency_key": idempotency_key,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = self._http_client.request(
@@ -207,11 +216,15 @@ class Organizations(OrganizationsModule):
         name: Optional[str] = None,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         stripe_customer_id: Optional[str] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> Organization:
         json = {
             "name": name,
             "domain_data": domain_data,
             "stripe_customer_id": stripe_customer_id,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = self._http_client.request(
@@ -291,6 +304,8 @@ class AsyncOrganizations(OrganizationsModule):
         name: str,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         idempotency_key: Optional[str] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> Organization:
         headers = {}
         if idempotency_key:
@@ -300,6 +315,8 @@ class AsyncOrganizations(OrganizationsModule):
             "name": name,
             "domain_data": domain_data,
             "idempotency_key": idempotency_key,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = await self._http_client.request(
@@ -318,11 +335,15 @@ class AsyncOrganizations(OrganizationsModule):
         name: Optional[str] = None,
         domain_data: Optional[Sequence[DomainDataInput]] = None,
         stripe_customer_id: Optional[str] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> Organization:
         json = {
             "name": name,
             "domain_data": domain_data,
             "stripe_customer_id": stripe_customer_id,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = await self._http_client.request(

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -60,13 +60,13 @@ class OrganizationsModule(Protocol):
         """
         ...
 
-    def get_organization_by_lookup_key(
-        self, lookup_key: str
+    def get_organization_by_external_id(
+        self, external_id: str
     ) -> SyncOrAsync[Organization]:
-        """Gets details for a single Organization by lookup key
+        """Gets details for a single Organization by external id
 
         Args:
-            lookup_key (str): Organization's lookup key
+            external_id (str): Organization's external id
 
         Returns:
             Organization: Organization response from WorkOS
@@ -125,7 +125,6 @@ class OrganizationsModule(Protocol):
 
 
 class Organizations(OrganizationsModule):
-
     _http_client: SyncHTTPClient
 
     def __init__(self, http_client: SyncHTTPClient):
@@ -167,9 +166,9 @@ class Organizations(OrganizationsModule):
 
         return Organization.model_validate(response)
 
-    def get_organization_by_lookup_key(self, lookup_key: str) -> Organization:
+    def get_organization_by_external_id(self, external_id: str) -> Organization:
         response = self._http_client.request(
-            "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
+            "organizations/external_id/{external_id}".format(external_id=external_id),
             method=REQUEST_METHOD_GET,
         )
 
@@ -237,7 +236,6 @@ class Organizations(OrganizationsModule):
 
 
 class AsyncOrganizations(OrganizationsModule):
-
     _http_client: AsyncHTTPClient
 
     def __init__(self, http_client: AsyncHTTPClient):
@@ -279,9 +277,9 @@ class AsyncOrganizations(OrganizationsModule):
 
         return Organization.model_validate(response)
 
-    async def get_organization_by_lookup_key(self, lookup_key: str) -> Organization:
+    async def get_organization_by_external_id(self, external_id: str) -> Organization:
         response = await self._http_client.request(
-            "organizations/by_lookup_key/{lookup_key}".format(lookup_key=lookup_key),
+            "organizations/external_id/{external_id}".format(external_id=external_id),
             method=REQUEST_METHOD_GET,
         )
 

--- a/workos/types/metadata.py
+++ b/workos/types/metadata.py
@@ -1,0 +1,4 @@
+from typing import Dict
+
+
+Metadata = Dict[str, str]

--- a/workos/types/organizations/organization.py
+++ b/workos/types/organizations/organization.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence
+from dataclasses import field
+from typing import Optional, Sequence, Dict
 from workos.types.organizations.organization_common import OrganizationCommon
 from workos.types.organizations.organization_domain import OrganizationDomain
 
@@ -8,3 +9,4 @@ class Organization(OrganizationCommon):
     domains: Sequence[OrganizationDomain]
     stripe_customer_id: Optional[str] = None
     external_id: Optional[str] = None
+    metadata: Dict[str, str] = field(default_factory=dict)

--- a/workos/types/organizations/organization.py
+++ b/workos/types/organizations/organization.py
@@ -1,5 +1,6 @@
 from dataclasses import field
-from typing import Optional, Sequence, Dict
+from typing import Optional, Sequence
+from workos.types.metadata import Metadata
 from workos.types.organizations.organization_common import OrganizationCommon
 from workos.types.organizations.organization_domain import OrganizationDomain
 
@@ -9,4 +10,4 @@ class Organization(OrganizationCommon):
     domains: Sequence[OrganizationDomain]
     stripe_customer_id: Optional[str] = None
     external_id: Optional[str] = None
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: Metadata = field(default_factory=dict)

--- a/workos/types/organizations/organization.py
+++ b/workos/types/organizations/organization.py
@@ -6,5 +6,5 @@ from workos.types.organizations.organization_domain import OrganizationDomain
 class Organization(OrganizationCommon):
     allow_profiles_outside_organization: bool
     domains: Sequence[OrganizationDomain]
-    lookup_key: Optional[str] = None
     stripe_customer_id: Optional[str] = None
+    external_id: Optional[str] = None

--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -1,5 +1,6 @@
 from dataclasses import field
-from typing import Literal, Optional, Dict
+from typing import Literal, Optional
+from workos.types.metadata import Metadata
 from workos.types.workos_model import WorkOSModel
 
 
@@ -17,4 +18,4 @@ class User(WorkOSModel):
     created_at: str
     updated_at: str
     external_id: Optional[str] = None
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: Metadata = field(default_factory=dict)

--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -1,4 +1,5 @@
-from typing import Literal, Optional
+from dataclasses import field
+from typing import Literal, Optional, Dict
 from workos.types.workos_model import WorkOSModel
 
 
@@ -16,3 +17,4 @@ class User(WorkOSModel):
     created_at: str
     updated_at: str
     external_id: Optional[str] = None
+    metadata: Dict[str, str] = field(default_factory=dict)

--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -15,3 +15,4 @@ class User(WorkOSModel):
     last_sign_in_at: Optional[str] = None
     created_at: str
     updated_at: str
+    external_id: Optional[str] = None

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -8,6 +8,7 @@ from workos.types.list_resource import (
     ListPage,
     WorkOSListResource,
 )
+from workos.types.metadata import Metadata
 from workos.types.mfa import (
     AuthenticationFactor,
     AuthenticationFactorTotpAndChallengeResponse,
@@ -183,6 +184,8 @@ class UserManagementModule(Protocol):
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         email_verified: Optional[bool] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> SyncOrAsync[User]:
         """Create a new user.
 
@@ -210,6 +213,8 @@ class UserManagementModule(Protocol):
         password: Optional[str] = None,
         password_hash: Optional[str] = None,
         password_hash_type: Optional[PasswordHashType] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> SyncOrAsync[User]:
         """Update user attributes.
 
@@ -917,6 +922,8 @@ class UserManagement(UserManagementModule):
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         email_verified: Optional[bool] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> User:
         json = {
             "email": email,
@@ -926,6 +933,8 @@ class UserManagement(UserManagementModule):
             "first_name": first_name,
             "last_name": last_name,
             "email_verified": email_verified or False,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = self._http_client.request(
@@ -944,6 +953,8 @@ class UserManagement(UserManagementModule):
         password: Optional[str] = None,
         password_hash: Optional[str] = None,
         password_hash_type: Optional[PasswordHashType] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> User:
         json = {
             "first_name": first_name,
@@ -952,6 +963,8 @@ class UserManagement(UserManagementModule):
             "password": password,
             "password_hash": password_hash,
             "password_hash_type": password_hash_type,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = self._http_client.request(
@@ -1529,6 +1542,8 @@ class AsyncUserManagement(UserManagementModule):
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         email_verified: Optional[bool] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> User:
         json = {
             "email": email,
@@ -1538,6 +1553,8 @@ class AsyncUserManagement(UserManagementModule):
             "first_name": first_name,
             "last_name": last_name,
             "email_verified": email_verified or False,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = await self._http_client.request(
@@ -1556,6 +1573,8 @@ class AsyncUserManagement(UserManagementModule):
         password: Optional[str] = None,
         password_hash: Optional[str] = None,
         password_hash_type: Optional[PasswordHashType] = None,
+        external_id: Optional[str] = None,
+        metadata: Optional[Metadata] = None,
     ) -> User:
         json = {
             "first_name": first_name,
@@ -1564,6 +1583,8 @@ class AsyncUserManagement(UserManagementModule):
             "password": password,
             "password_hash": password_hash,
             "password_hash_type": password_hash_type,
+            "external_id": external_id,
+            "metadata": metadata,
         }
 
         response = await self._http_client.request(

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -66,6 +66,7 @@ from workos.utils.request_helper import (
 
 USER_PATH = "user_management/users"
 USER_DETAIL_PATH = "user_management/users/{0}"
+USER_DETAIL_BY_EXTERNAL_ID_PATH = "user_management/users/external_id/{0}"
 ORGANIZATION_MEMBERSHIP_PATH = "user_management/organization_memberships"
 ORGANIZATION_MEMBERSHIP_DETAIL_PATH = "user_management/organization_memberships/{0}"
 ORGANIZATION_MEMBERSHIP_DEACTIVATE_PATH = (
@@ -132,6 +133,16 @@ class UserManagementModule(Protocol):
 
         Args:
             user_id (str): User unique identifier
+        Returns:
+            User: User response from WorkOS.
+        """
+        ...
+
+    def get_user_by_external_id(self, external_id: str) -> SyncOrAsync[User]:
+        """Get the details of an existing user.
+
+        Args:
+            external_id (str): The user's external id
         Returns:
             User: User response from WorkOS.
         """
@@ -389,7 +400,6 @@ class UserManagementModule(Protocol):
             )
 
         if connection_id is not None:
-
             params["connection_id"] = connection_id
         if organization_id is not None:
             params["organization_id"] = organization_id
@@ -856,6 +866,14 @@ class UserManagement(UserManagementModule):
     def get_user(self, user_id: str) -> User:
         response = self._http_client.request(
             USER_DETAIL_PATH.format(user_id), method=REQUEST_METHOD_GET
+        )
+
+        return User.model_validate(response)
+
+    def get_user_by_external_id(self, external_id: str) -> User:
+        response = self._http_client.request(
+            USER_DETAIL_BY_EXTERNAL_ID_PATH.format(external_id),
+            method=REQUEST_METHOD_GET,
         )
 
         return User.model_validate(response)
@@ -1460,6 +1478,14 @@ class AsyncUserManagement(UserManagementModule):
     async def get_user(self, user_id: str) -> User:
         response = await self._http_client.request(
             USER_DETAIL_PATH.format(user_id), method=REQUEST_METHOD_GET
+        )
+
+        return User.model_validate(response)
+
+    async def get_user_by_external_id(self, external_id: str) -> User:
+        response = await self._http_client.request(
+            USER_DETAIL_BY_EXTERNAL_ID_PATH.format(external_id),
+            method=REQUEST_METHOD_GET,
         )
 
         return User.model_validate(response)

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -139,10 +139,10 @@ class UserManagementModule(Protocol):
         ...
 
     def get_user_by_external_id(self, external_id: str) -> SyncOrAsync[User]:
-        """Get the details of an existing user.
+        """Get the details of an existing user by external id.
 
         Args:
-            external_id (str): The user's external id
+            external_id (str): User's external id
         Returns:
             User: User response from WorkOS.
         """


### PR DESCRIPTION
## Description

Adds external_id and metadata properties to both users and organizations.

Also adds a get_[resource]_by_external_id for users and organizations and deletes the now defunct get_organization_by_lookup_key method.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.