### PR TITLE
ron: adding support for context param

### DIFF
--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -345,6 +345,7 @@ class UserManagementModule(Protocol):
         code_challenge: Optional[str] = None,
         prompt: Optional[str] = None,
         screen_hint: Optional[ScreenHintType] = None,
+        context: Optional[str] = None,
     ) -> str:
         """Generate an OAuth 2.0 authorization URL.
 


### PR DESCRIPTION
## Description
Adds support for the `context` param which is needed when you set the Login Endpoint URI
## Documentation
forthcoming documentation 
Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.