### PR TITLE
Don't arbitrarily constrain dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-httpx~=0.28.1
-pydantic~=2.10.4
+httpx>=0.28.1
+pydantic>=2.10.4
 PyJWT>=2.9.0, <2.10 ; python_version == "3.8"
 PyJWT>=2.10.0; python_version > "3.8"
-cryptography>=42.0.8, <45
+cryptography>=42.0.8


### PR DESCRIPTION
## Description

For libraries, the best practice is to only list **known incompatibilities** and not _potential_ future incompatibilities. Using `<=` (or `~=`) constraints can:

- Lead to dependency resolution conflicts for downstream consumers
- Prevent users from using newer versions of dependencies that are likely still compatible
- Reduce composability in larger environments or monorepos

Note how `pydantic` itself has no [`<=` constraints](https://github.com/pydantic/pydantic/blob/main/pyproject.toml#L45). You'll find the same with other libraries.