### PR TITLE
add password_reset.succeeded event type

### DIFF
--- a/workos/types/events/event.py
+++ b/workos/types/events/event.py
@@ -209,6 +209,10 @@ class PasswordResetCreatedEvent(EventModel[PasswordResetCommon]):
     event: Literal["password_reset.created"]
 
 
+class PasswordResetSucceededEvent(EventModel[PasswordResetCommon]):
+    event: Literal["password_reset.succeeded"]
+
+
 class RoleCreatedEvent(EventModel[EventRole]):
     event: Literal["role.created"]
 
@@ -274,6 +278,7 @@ Event = Annotated[
         OrganizationMembershipDeletedEvent,
         OrganizationMembershipUpdatedEvent,
         PasswordResetCreatedEvent,
+        PasswordResetSucceededEvent,
         RoleCreatedEvent,
         RoleDeletedEvent,
         RoleUpdatedEvent,

--- a/workos/types/events/event_type.py
+++ b/workos/types/events/event_type.py
@@ -40,6 +40,7 @@ EventType = Literal[
     "organization_membership.deleted",
     "organization_membership.updated",
     "password_reset.created",
+    "password_reset.succeeded",
     "role.created",
     "role.deleted",
     "role.updated",

--- a/workos/types/webhooks/webhook.py
+++ b/workos/types/webhooks/webhook.py
@@ -213,6 +213,10 @@ class PasswordResetCreatedWebhook(WebhookModel[PasswordResetCommon]):
     event: Literal["password_reset.created"]
 
 
+class PasswordResetSucceededWebhook(WebhookModel[PasswordResetCommon]):
+    event: Literal["password_reset.succeeded"]
+
+
 class RoleCreatedWebhook(WebhookModel[EventRole]):
     event: Literal["role.created"]
 
@@ -278,6 +282,7 @@ Webhook = Annotated[
         OrganizationMembershipDeletedWebhook,
         OrganizationMembershipUpdatedWebhook,
         PasswordResetCreatedWebhook,
+        PasswordResetSucceededWebhook,
         RoleCreatedWebhook,
         RoleDeletedWebhook,
         RoleUpdatedWebhook,


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4441/add-password-resetsucceeded-event-to-python-sdk

adds support for password_reset.succeeded event type

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.