### PR TITLE
Allow organization_id to be optional on Connection for OAuth connections

### DIFF
--- a/workos/types/sso/connection.py
+++ b/workos/types/sso/connection.py
@@ -54,7 +54,7 @@ class SamlConnectionOptions(WorkOSModel):
 class Connection(WorkOSModel):
     object: Literal["connection"]
     id: str
-    organization_id: Optional[str]
+    organization_id: Optional[str] = None
     connection_type: LiteralOrUntyped[ConnectionType]
     name: str
     state: LiteralOrUntyped[ConnectionState]

--- a/workos/types/sso/connection.py
+++ b/workos/types/sso/connection.py
@@ -54,7 +54,7 @@ class SamlConnectionOptions(WorkOSModel):
 class Connection(WorkOSModel):
     object: Literal["connection"]
     id: str
-    organization_id: str
+    organization_id: Optional[str]
     connection_type: LiteralOrUntyped[ConnectionType]
     name: str
     state: LiteralOrUntyped[ConnectionState]


### PR DESCRIPTION
## Description
Allow `organization_id` to be optional on `Connection` for OAuth connections.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.