### PR TITLE
Add custom_attributes field to SSO Profile

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -29,7 +29,7 @@ class SSOFixtures:
             idp_id="",
             first_name=None,
             last_name=None,
-            profile=None,
+            role=None,
             groups=None,
             raw_attributes={},
         ).dict()

--- a/tests/utils/fixtures/mock_profile.py
+++ b/tests/utils/fixtures/mock_profile.py
@@ -6,7 +6,7 @@ class MockProfile(Profile):
     def __init__(self, id: str):
         super().__init__(
             object="profile",
-            id="prof_01DWAS7ZQWM70PV93BFV1V78QV",
+            id=id or "prof_01DWAS7ZQWM70PV93BFV1V78QV",
             email="demo@workos-okta.com",
             first_name="WorkOS",
             last_name="Demo",
@@ -16,10 +16,14 @@ class MockProfile(Profile):
             connection_id="conn_01EMH8WAK20T42N2NBMNBCYHAG",
             connection_type="OktaSAML",
             idp_id="00u1klkowm8EGah2H357",
+            custom_attributes={
+                "license": "professional",
+            },
             raw_attributes={
                 "email": "demo@workos-okta.com",
                 "first_name": "WorkOS",
                 "last_name": "Demo",
                 "groups": ["Admins", "Developers"],
+                "license": "professional",
             },
         )

--- a/workos/types/sso/profile.py
+++ b/workos/types/sso/profile.py
@@ -23,7 +23,8 @@ class Profile(WorkOSModel):
     idp_id: str
     role: Optional[ProfileRole] = None
     groups: Optional[Sequence[str]] = None
-    raw_attributes: Mapping[str, Any]
+    custom_attributes: Optional[Mapping[str, Any]] = None
+    raw_attributes: Optional[Mapping[str, Any]] = None
 
 
 class ProfileAndToken(WorkOSModel):


### PR DESCRIPTION
## Description
Add `custom_attributes` field to SSO Profile.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.