### PR TITLE
Bump cryptography to ~=44.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ httpx>=0.28.1
 pydantic>=2.10.4
 PyJWT>=2.9.0, <2.10 ; python_version == "3.8"
 PyJWT>=2.10.0; python_version > "3.8"
-cryptography>=42.0.8
+cryptography>=44.0.2


### PR DESCRIPTION
## Description
This was causing a dependency conflict when trying to install workos in our api. For the time being we've had to downgrade cryptography back to ~=42.0.8 to satisfy the conflict.

Looking through the changelog and codebase I can't find anything that should require refactoring. 

## Documentation
https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst


Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.