### PR TITLE
Convert context into query string for FGA queries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from typing import (
     cast,
 )
 from unittest.mock import AsyncMock, MagicMock
+import urllib.parse
 
 import httpx
 import pytest
@@ -161,6 +162,14 @@ def capture_and_mock_http_client_request(monkeypatch):
 
         def capture_and_mock(*args, **kwargs):
             request_kwargs.update(kwargs)
+
+            # Capture full URL with encoded params while keeping original URL
+            if kwargs and "params" in kwargs and kwargs["params"]:
+                # Convert params to query string with proper URL encoding
+                query_string = urllib.parse.urlencode(
+                    kwargs["params"], doseq=True, quote_via=urllib.parse.quote_plus
+                )
+                request_kwargs.update({"full_url": f"{kwargs['url']}?{query_string}"})
 
             return httpx.Response(
                 status_code=status_code,

--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -535,7 +535,9 @@ class TestFGA:
         )
         assert response.dict(exclude_none=True) == mock_query_response
 
-    def test_query_with_context(self, mock_query_response, mock_http_client_with_response):
+    def test_query_with_context(
+        self, mock_query_response, mock_http_client_with_response
+    ):
         mock_http_client_with_response(self.http_client, mock_query_response, 200)
 
         response = self.fga.query(

--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -536,9 +536,11 @@ class TestFGA:
         assert response.dict(exclude_none=True) == mock_query_response
 
     def test_query_with_context(
-        self, mock_query_response, mock_http_client_with_response
+        self, mock_query_response, capture_and_mock_http_client_request
     ):
-        mock_http_client_with_response(self.http_client, mock_query_response, 200)
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_query_response, 200
+        )
 
         response = self.fga.query(
             q="select member of type user for permission:view-docs",
@@ -546,4 +548,8 @@ class TestFGA:
             warrant_token="warrant_token",
             context={"region": "us", "subscription": "pro"},
         )
+
+        assert request_kwargs["url"] == "https://api.workos.test/fga/v1/query"
+        expected_full_url = "https://api.workos.test/fga/v1/query?q=select+member+of+type+user+for+permission%3Aview-docs&limit=10&order=asc&context=%7B%22region%22%3A+%22us%22%2C+%22subscription%22%3A+%22pro%22%7D"
+        assert request_kwargs["full_url"] == expected_full_url
         assert response.dict(exclude_none=True) == mock_query_response

--- a/tests/test_fga.py
+++ b/tests/test_fga.py
@@ -534,3 +534,14 @@ class TestFGA:
             warrant_token="warrant_token",
         )
         assert response.dict(exclude_none=True) == mock_query_response
+
+    def test_query_with_context(self, mock_query_response, mock_http_client_with_response):
+        mock_http_client_with_response(self.http_client, mock_query_response, 200)
+
+        response = self.fga.query(
+            q="select member of type user for permission:view-docs",
+            order="asc",
+            warrant_token="warrant_token",
+            context={"region": "us", "subscription": "pro"},
+        )
+        assert response.dict(exclude_none=True) == mock_query_response

--- a/workos/fga.py
+++ b/workos/fga.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Mapping, Optional, Protocol, Sequence
 from workos.types.fga import (
     CheckOperation,
@@ -621,11 +622,16 @@ class FGA(FGAModule):
             "after": after,
             "context": context,
         }
+        parsed_list_params = {
+            key: json.dumps(value) if key == "context" and value is not None else value
+            for key, value in list_params.items()
+            if value is not None
+        }
 
         response = self._http_client.request(
             "fga/v1/query",
             method=REQUEST_METHOD_GET,
-            params=list_params,
+            params=parsed_list_params,
             headers={"Warrant-Token": warrant_token} if warrant_token else None,
         )
 


### PR DESCRIPTION
## Description

This PR updates the FGA `query` method to convert the `context` param from a dictionary to a string before making the request.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.