### PR TITLE
Avoid decoding jwt twice

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -236,9 +236,7 @@ class TestSessionBase(SessionFixtures):
             "entitlements": ["feature_1"],
         }
 
-        with patch.object(
-            Session, "unseal_data", return_value=mock_session
-        ), patch.object(session, "_is_valid_jwt", return_value=True), patch(
+        with patch.object(Session, "unseal_data", return_value=mock_session), patch(
             "jwt.decode", return_value=mock_jwt_payload
         ), patch.object(
             session.jwks,
@@ -324,22 +322,21 @@ class TestSession(SessionFixtures):
             cookie_password=session_constants["COOKIE_PASSWORD"],
         )
 
-        with patch.object(session, "_is_valid_jwt", return_value=True) as _:
-            with patch(
-                "jwt.decode",
-                return_value={
-                    "sid": session_constants["SESSION_ID"],
-                    "org_id": session_constants["ORGANIZATION_ID"],
-                    "role": "admin",
-                    "permissions": ["read"],
-                    "entitlements": ["feature_1"],
-                },
-            ):
-                response = session.refresh()
+        with patch(
+            "jwt.decode",
+            return_value={
+                "sid": session_constants["SESSION_ID"],
+                "org_id": session_constants["ORGANIZATION_ID"],
+                "role": "admin",
+                "permissions": ["read"],
+                "entitlements": ["feature_1"],
+            },
+        ):
+            response = session.refresh()
 
-                assert isinstance(response, RefreshWithSessionCookieSuccessResponse)
-                assert response.authenticated is True
-                assert response.user.id == session_constants["TEST_USER"]["id"]
+            assert isinstance(response, RefreshWithSessionCookieSuccessResponse)
+            assert response.authenticated is True
+            assert response.user.id == session_constants["TEST_USER"]["id"]
 
         # Verify the refresh token was used correctly
         mock_user_management.authenticate_with_refresh_token.assert_called_once_with(
@@ -425,22 +422,21 @@ class TestAsyncSession(SessionFixtures):
             cookie_password=session_constants["COOKIE_PASSWORD"],
         )
 
-        with patch.object(session, "_is_valid_jwt", return_value=True) as _:
-            with patch(
-                "jwt.decode",
-                return_value={
-                    "sid": session_constants["SESSION_ID"],
-                    "org_id": session_constants["ORGANIZATION_ID"],
-                    "role": "admin",
-                    "permissions": ["read"],
-                    "entitlements": ["feature_1"],
-                },
-            ):
-                response = await session.refresh()
+        with patch(
+            "jwt.decode",
+            return_value={
+                "sid": session_constants["SESSION_ID"],
+                "org_id": session_constants["ORGANIZATION_ID"],
+                "role": "admin",
+                "permissions": ["read"],
+                "entitlements": ["feature_1"],
+            },
+        ):
+            response = await session.refresh()
 
-                assert isinstance(response, RefreshWithSessionCookieSuccessResponse)
-                assert response.authenticated is True
-                assert response.user.id == session_constants["TEST_USER"]["id"]
+            assert isinstance(response, RefreshWithSessionCookieSuccessResponse)
+            assert response.authenticated is True
+            assert response.user.id == session_constants["TEST_USER"]["id"]
 
         # Verify the refresh token was used correctly
         mock_user_management.authenticate_with_refresh_token.assert_called_once_with(

--- a/workos/session.py
+++ b/workos/session.py
@@ -77,19 +77,19 @@ class SessionModule(Protocol):
                 reason=AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE,
             )
 
-        if not self._is_valid_jwt(session["access_token"]):
+        try:
+            signing_key = self.jwks.get_signing_key_from_jwt(session["access_token"])
+            decoded = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=self.jwk_algorithms,
+                options={"verify_aud": False},
+            )
+        except jwt.exceptions.InvalidTokenError:
             return AuthenticateWithSessionCookieErrorResponse(
                 authenticated=False,
                 reason=AuthenticateWithSessionCookieFailureReason.INVALID_JWT,
             )
-
-        signing_key = self.jwks.get_signing_key_from_jwt(session["access_token"])
-        decoded = jwt.decode(
-            session["access_token"],
-            signing_key.key,
-            algorithms=self.jwk_algorithms,
-            options={"verify_aud": False},
-        )
 
         return AuthenticateWithSessionCookieSuccessResponse(
             authenticated=True,
@@ -127,19 +127,6 @@ class SessionModule(Protocol):
             return_to=return_to,
         )
         return str(result)
-
-    def _is_valid_jwt(self, token: str) -> bool:
-        try:
-            signing_key = self.jwks.get_signing_key_from_jwt(token)
-            jwt.decode(
-                token,
-                signing_key.key,
-                algorithms=self.jwk_algorithms,
-                options={"verify_aud": False},
-            )
-            return True
-        except jwt.exceptions.InvalidTokenError:
-            return False
 
     @staticmethod
     def seal_data(data: Dict[str, Any], key: str) -> str:

--- a/workos/session.py
+++ b/workos/session.py
@@ -80,7 +80,7 @@ class SessionModule(Protocol):
         try:
             signing_key = self.jwks.get_signing_key_from_jwt(session["access_token"])
             decoded = jwt.decode(
-                token,
+                session["access_token"],
                 signing_key.key,
                 algorithms=self.jwk_algorithms,
                 options={"verify_aud": False},


### PR DESCRIPTION
## Description
Currently the Session::authenticate() function (which runs on every request and consumes CPU cycles) is decoding the jwt twice unnecessarily. This small refactor fixes that

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

No