### PR TITLE
Add warnings field to FGA check / query response

### DIFF
--- a/workos/fga.py
+++ b/workos/fga.py
@@ -10,7 +10,8 @@ from workos.types.fga import (
     WarrantWrite,
     WarrantWriteOperation,
     WriteWarrantResponse,
-    WarrantQueryResult, FGAWarning,
+    WarrantQueryResult,
+    FGAWarning,
 )
 from workos.types.fga.list_filters import (
     AuthorizationResourceListFilters,
@@ -46,9 +47,9 @@ AuthorizationResourceTypeListResource = WorkOSListResource[
 WarrantListResource = WorkOSListResource[Warrant, WarrantListFilters, ListMetadata]
 
 
-class WarrantQueryListResource(WorkOSListResource[
-                                   WarrantQueryResult, WarrantQueryListFilters, ListMetadata
-                               ]):
+class WarrantQueryListResource(
+    WorkOSListResource[WarrantQueryResult, WarrantQueryListFilters, ListMetadata]
+):
     warnings: Optional[Sequence[FGAWarning]] = None
 
 

--- a/workos/fga.py
+++ b/workos/fga.py
@@ -10,7 +10,7 @@ from workos.types.fga import (
     WarrantWrite,
     WarrantWriteOperation,
     WriteWarrantResponse,
-    WarrantQueryResult,
+    WarrantQueryResult, FGAWarning,
 )
 from workos.types.fga.list_filters import (
     AuthorizationResourceListFilters,
@@ -45,9 +45,11 @@ AuthorizationResourceTypeListResource = WorkOSListResource[
 
 WarrantListResource = WorkOSListResource[Warrant, WarrantListFilters, ListMetadata]
 
-WarrantQueryListResource = WorkOSListResource[
-    WarrantQueryResult, WarrantQueryListFilters, ListMetadata
-]
+
+class WarrantQueryListResource(WorkOSListResource[
+                                   WarrantQueryResult, WarrantQueryListFilters, ListMetadata
+                               ]):
+    warnings: Optional[Sequence[FGAWarning]] = None
 
 
 class FGAModule(Protocol):
@@ -641,5 +643,6 @@ class FGA(FGAModule):
         return WarrantQueryListResource(
             list_method=self.query,
             list_args=list_params,
+            warnings=response.get("warnings"),
             **ListPage[WarrantQueryResult](**response).model_dump(),
         )

--- a/workos/types/fga/__init__.py
+++ b/workos/types/fga/__init__.py
@@ -2,3 +2,4 @@ from .check import *
 from .authorization_resource_types import *
 from .authorization_resources import *
 from .warrant import *
+from .warnings import *

--- a/workos/types/fga/check.py
+++ b/workos/types/fga/check.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
 from workos.types.workos_model import WorkOSModel
 from workos.typing.literals import LiteralOrUntyped
 
+from .warnings import FGAWarning
 from .warrant import Subject, SubjectInput
 
 CheckOperation = Literal["any_of", "all_of", "batch"]
@@ -44,6 +45,7 @@ class CheckResponse(WorkOSModel):
     result: LiteralOrUntyped[CheckResult]
     is_implicit: bool
     debug_info: Optional[DebugInfo] = None
+    warnings: Optional[Sequence[FGAWarning]] = None
 
     def authorized(self) -> bool:
         return self.result == "authorized"

--- a/workos/types/fga/warnings.py
+++ b/workos/types/fga/warnings.py
@@ -1,4 +1,5 @@
-from typing import Sequence, Annotated, Union, Any, Dict
+from typing import Sequence, Union, Any, Dict, Literal
+from typing_extensions import Annotated
 
 from pydantic import BeforeValidator
 from pydantic_core.core_schema import ValidationInfo
@@ -12,6 +13,7 @@ class FGABaseWarning(WorkOSModel):
 
 
 class MissingContextKeysWarning(FGABaseWarning):
+    code: Literal["missing_context_keys"]
     keys: Sequence[str]
 
 
@@ -20,6 +22,8 @@ def fga_warning_dispatch_validator(
 ) -> FGABaseWarning:
     if value.get("code") == "missing_context_keys":
         return MissingContextKeysWarning.model_validate(value)
+
+    # Fallback to the base warning model
     return FGABaseWarning.model_validate(value)
 
 

--- a/workos/types/fga/warnings.py
+++ b/workos/types/fga/warnings.py
@@ -1,0 +1,21 @@
+from typing import Sequence, Union, Literal, Annotated
+
+from pydantic import Field
+
+from workos.types.workos_model import WorkOSModel
+
+
+class FGABaseWarning(WorkOSModel):
+    code: str
+    message: str
+
+
+class MissingContextKeysWarning(FGABaseWarning):
+    code: Literal["missing_context_keys"]
+    keys: Sequence[str]
+
+
+FGAWarning = Annotated[
+    Union[MissingContextKeysWarning, FGABaseWarning],
+    Field(discriminator='type')
+]


### PR DESCRIPTION
## Description
Adds warning field to check and query response

```json
 "warnings": [
    {
        "code": "missing_context_keys",
        "message": "missing context keys required to evaluate policies - results may be incomplete",
        "keys": [
            "clientIp",
            "element1",
            "element2"
        ]
    }
]
```