### PR TITLE
[Cross-SDK Sync] Add `email` to `updateUser` options

### DIFF
--- a/workos/user_management/update_user_options.py
+++ b/workos/user_management/update_user_options.py
@@ -1,0 +1,11 @@
+def serialize_update_user_options(options):
+    return {
+        'email': options['email'],
+        'email_verified': options['emailVerified'],
+        'first_name': options['firstName'],
+        'last_name': options['lastName'],
+        'password': options['password'],
+        'password_hash': options['passwordHash'],
+        'password_hash_type': options['passwordHashType'],
+        'external_id': options['externalId'],
+    }


### PR DESCRIPTION
# Automated Cross-SDK Sync

This PR was automatically translated from node PR #1273.

## Original Description
## Description

Adds `email` to the `userManagement.updateUser`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


