### PR TITLE
[Cross-SDK Sync] Add `email` to `updateUser` options

### DIFF
--- a/workos/types/user.py
+++ b/workos/types/user.py
@@ -1,0 +1,47 @@
+from typing import Optional
+from workos.types.password_hash_type import PasswordHashType
+
+class UpdateUserOptions:
+    def __init__(
+        self,
+        user_id: str,
+        email: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        email_verified: Optional[bool] = None,
+        password: Optional[str] = None,
+        password_hash: Optional[str] = None,
+        password_hash_type: Optional[PasswordHashType] = None,
+        external_id: Optional[str] = None,
+    ):
+        self.user_id = user_id
+        self.email = email
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email_verified = email_verified
+        self.password = password
+        self.password_hash = password_hash
+        self.password_hash_type = password_hash_type
+        self.external_id = external_id
+
+
+class SerializedUpdateUserOptions:
+    def __init__(
+        self,
+        email: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        email_verified: Optional[bool] = None,
+        password: Optional[str] = None,
+        password_hash: Optional[str] = None,
+        password_hash_type: Optional[PasswordHashType] = None,
+        external_id: Optional[str] = None,
+    ):
+        self.email = email
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email_verified = email_verified
+        self.password = password
+        self.password_hash = password_hash
+        self.password_hash_type = password_hash_type
+        self.external_id = external_id


### PR DESCRIPTION
# Automated Cross-SDK Sync

This PR was automatically translated from node PR #1273.

## Original Description
## Description

Adds `email` to the `userManagement.updateUser`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



## Manual Attention Required

The following files could not be automatically translated and require manual review:

### src/user-management/serializers/update-user-options.serializer.ts
- **Reason**: 429 Request too large for gpt-4 in organization org-axlJZVuSJpVAdfdgHQucgPh1 on tokens per min (TPM): Limit 10000, Requested 20609. The input or output tokens must be reduced in order to run successfully. Visit https://platform.openai.com/account/rate-limits to learn more.

