### PR TITLE
[Cross-SDK Sync] Add `email` to `updateUser` options

### DIFF
--- a/workos/types/user_management/user.py
+++ b/workos/types/user_management/user.py
@@ -9,10 +9,10 @@ class User(WorkOSModel):
 
     object: Literal["user"]
     id: str
-    email: str
+    email: Optional[str] = None
+    email_verified: bool
     first_name: Optional[str] = None
     last_name: Optional[str] = None
-    email_verified: bool
     profile_picture_url: Optional[str] = None
     last_sign_in_at: Optional[str] = None
     created_at: str


### PR DESCRIPTION
# Automated Cross-SDK Sync

This PR was automatically translated from node PR #1273.

## Original Description
## Description

Adds `email` to the `userManagement.updateUser`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



## Translation Notes

### src/user-management/interfaces/update-user-options.interface.ts
- The 'email' field in the User class is now optional to match the changes made in the source file.

### src/user-management/serializers/update-user-options.serializer.ts
- No changes were needed in the Python code. The 'email' field already exists in the User class.

