### PR TITLE
Add new supported password hash types

### DIFF
--- a/workos/types/user_management/password_hash_type.py
+++ b/workos/types/user_management/password_hash_type.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
 
-PasswordHashType = Literal["bcrypt", "firebase-scrypt", "ssha"]
+PasswordHashType = Literal["bcrypt", "firebase-scrypt", "pbkdf2", "scrypt", "ssha"]


### PR DESCRIPTION
Fixes #460

## Description
The types in the python library didn't match the list of valid hash types at https://workos.com/docs/migrate/other-services/2-importing-users-into-workos/importing-passwords

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.