### PR TITLE
Expose delete endpoint for organization_domains - DAAP-1753

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -218,6 +218,25 @@ class TestOrganizations:
         assert request_kwargs["method"] == "delete"
         assert response is None
 
+    def test_delete_organization_domain(self, capture_and_mock_http_client_request):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client,
+            204,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        )
+
+        response = syncify(
+            self.organizations.delete_organization_domain(
+                organization_domain_id="org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
+            )
+        )
+
+        assert request_kwargs["url"].endswith(
+            "/organization_domains/org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
+        )
+        assert request_kwargs["method"] == "delete"
+        assert response is None
+
     def test_list_organizations_auto_pagination_for_single_page(
         self,
         mock_organizations_single_page_response,

--- a/workos/organizations.py
+++ b/workos/organizations.py
@@ -128,6 +128,19 @@ class OrganizationsModule(Protocol):
         """
         ...
 
+    def delete_organization_domain(
+        self, organization_domain_id: str
+    ) -> SyncOrAsync[None]:
+        """Deletes a single Organization Domain
+
+        Args:
+            organization_domain_id (str): Organization Domain unique identifier
+
+        Returns:
+            None
+        """
+        ...
+
 
 class Organizations(OrganizationsModule):
     _http_client: SyncHTTPClient
@@ -236,6 +249,12 @@ class Organizations(OrganizationsModule):
     def delete_organization(self, organization_id: str) -> None:
         self._http_client.request(
             f"organizations/{organization_id}",
+            method=REQUEST_METHOD_DELETE,
+        )
+
+    def delete_organization_domain(self, organization_domain_id: str) -> None:
+        self._http_client.request(
+            f"organization_domains/{organization_domain_id}",
             method=REQUEST_METHOD_DELETE,
         )
 
@@ -355,6 +374,12 @@ class AsyncOrganizations(OrganizationsModule):
     async def delete_organization(self, organization_id: str) -> None:
         await self._http_client.request(
             f"organizations/{organization_id}",
+            method=REQUEST_METHOD_DELETE,
+        )
+
+    async def delete_organization_domain(self, organization_domain_id: str) -> None:
+        await self._http_client.request(
+            f"organization_domains/{organization_domain_id}",
             method=REQUEST_METHOD_DELETE,
         )
 


### PR DESCRIPTION
## Description

Exposes an SDK method to delete an organization domain

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

Docs PR:
https://github.com/workos/workos/pull/42288
