### PR TITLE
Cache JWKS clients per URL

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import concurrent.futures
 
 from tests.conftest import with_jwks_mock
-from workos.session import AsyncSession, Session, _get_jwks_client, _jwks_cache
+from workos.session import AsyncSession, Session, _get_jwks_client
 from workos.types.user_management.authentication_response import (
     RefreshTokenAuthenticationResponse,
 )
@@ -23,9 +23,9 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 class SessionFixtures:
     @pytest.fixture(autouse=True)
     def clear_jwks_cache(self):
-        _jwks_cache.clear()
+        _get_jwks_client.cache_clear()
         yield
-        _jwks_cache.clear()
+        _get_jwks_client.cache_clear()
 
     @pytest.fixture
     def session_constants(self):
@@ -521,7 +521,7 @@ class TestJWKSCaching:
         # Should be different instances
         assert client1 is not client2
         assert id(client1) != id(client2)
-    
+
     def test_jwks_cache_thread_safety(self):
         url = "https://api.workos.com/sso/jwks/thread_test"
         clients = []


### PR DESCRIPTION
## Description

Previously, any time a session was initiated, a separate JWKS client was created for each instance. Even though each instance individually cached the results of fetching the JWKS, these weren't getting meaningfully re-used.

This PR creates a cache that stores JWKS clients per JWKS URL. Rather than instantiating their own instances of the JWKS client, the session instances will now fetch them from the cache.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.