### PR TITLE
Add Salesforce OAuth as an authentication provider

### DIFF
--- a/workos/types/sso/connection.py
+++ b/workos/types/sso/connection.py
@@ -37,6 +37,7 @@ ConnectionType = Literal[
     "PingFederateSAML",
     "PingOneSAML",
     "RipplingSAML",
+    "SalesforceOAuth",
     "SalesforceSAML",
     "ShibbolethGenericSAML",
     "ShibbolethSAML",

--- a/workos/types/sso/sso_provider_type.py
+++ b/workos/types/sso/sso_provider_type.py
@@ -6,4 +6,5 @@ SsoProviderType = Literal[
     "GitHubOAuth",
     "GoogleOAuth",
     "MicrosoftOAuth",
+    "SalesforceOAuth",
 ]

--- a/workos/types/user_management/authentication_response.py
+++ b/workos/types/user_management/authentication_response.py
@@ -13,6 +13,7 @@ AuthenticationMethod = Literal[
     "GitHubOAuth",
     "GoogleOAuth",
     "MicrosoftOAuth",
+    "SalesforceOAuth",
     "MagicAuth",
     "Impersonation",
 ]

--- a/workos/types/user_management/oauth_tokens.py
+++ b/workos/types/user_management/oauth_tokens.py
@@ -7,6 +7,7 @@ OAuthTokensProvidersType = Literal[
     "GitHubOauth",
     "GoogleOauth",
     "MicrosoftOauth",
+    "SalesforceOauth",
 ]
 
 

--- a/workos/types/user_management/user_management_provider_type.py
+++ b/workos/types/user_management/user_management_provider_type.py
@@ -2,5 +2,10 @@ from typing import Literal
 
 
 UserManagementProviderType = Literal[
-    "authkit", "AppleOAuth", "GitHubOAuth", "GoogleOAuth", "MicrosoftOAuth"
+    "authkit",
+    "AppleOAuth",
+    "GitHubOAuth",
+    "GoogleOAuth",
+    "MicrosoftOAuth",
+    "SalesforceOAuth",
 ]

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -396,7 +396,7 @@ class UserManagementModule(Protocol):
             organization_id (str): The organization_id connection selector is used to initiate SSO for an Organization.
                 The value of this parameter should be a WorkOS Organization ID. (Optional)
             provider (UserManagementProviderType): The provider connection selector is used to initiate SSO using an OAuth-compatible provider.
-                Currently, the supported values for provider are 'authkit', 'AppleOAuth', 'GitHubOAuth, 'GoogleOAuth', and 'MicrosoftOAuth'. (Optional)
+                Currently, the supported values for provider are 'authkit', 'AppleOAuth', 'GitHubOAuth, 'GoogleOAuth', 'MicrosoftOAuth', and 'SalesforceOAuth'. (Optional)
             provider_scopes (Sequence[str]): Can be used to specify additional scopes that will be requested when initiating SSO using an OAuth provider. (Optional)
             domain_hint (str): Can be used to pre-fill the domain field when initiating authentication with Microsoft OAuth,
                 or with a GoogleSAML connection type. (Optional)


### PR DESCRIPTION
## Description

We are rolling out support for Salesforce OAuth. This adds it to the list of providers.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.