### PR TITLE
Add support for list organization feature flags endpoint

### DIFF
--- a/tests/utils/fixtures/mock_feature_flag.py
+++ b/tests/utils/fixtures/mock_feature_flag.py
@@ -1,0 +1,17 @@
+import datetime
+
+from workos.types.feature_flags.feature_flag import FeatureFlag
+
+
+class MockFeatureFlag(FeatureFlag):
+    def __init__(self, id):
+        now = datetime.datetime.now().isoformat()
+        super().__init__(
+            object="feature_flag",
+            id=id,
+            slug="test-feature",
+            name="Test Feature",
+            description="A test feature flag",
+            created_at=now,
+            updated_at=now,
+        )

--- a/workos/types/feature_flags/__init__.py
+++ b/workos/types/feature_flags/__init__.py
@@ -1,0 +1,3 @@
+from workos.types.feature_flags.feature_flag import FeatureFlag
+
+__all__ = ["FeatureFlag"]

--- a/workos/types/feature_flags/feature_flag.py
+++ b/workos/types/feature_flags/feature_flag.py
@@ -1,0 +1,12 @@
+from typing import Literal, Optional
+from workos.types.workos_model import WorkOSModel
+
+
+class FeatureFlag(WorkOSModel):
+    id: str
+    object: Literal["feature_flag"]
+    slug: str
+    name: str
+    description: Optional[str]
+    created_at: str
+    updated_at: str

--- a/workos/types/feature_flags/list_filters.py
+++ b/workos/types/feature_flags/list_filters.py
@@ -1,0 +1,5 @@
+from workos.types.list_resource import ListArgs
+
+
+class FeatureFlagListFilters(ListArgs, total=False):
+    pass

--- a/workos/types/list_resource.py
+++ b/workos/types/list_resource.py
@@ -23,6 +23,7 @@ from workos.types.directory_sync import (
     DirectoryUserWithGroups,
 )
 from workos.types.events import Event
+from workos.types.feature_flags import FeatureFlag
 from workos.types.fga import (
     Warrant,
     AuthorizationResource,
@@ -46,6 +47,7 @@ ListableResource = TypeVar(
     DirectoryGroup,
     DirectoryUserWithGroups,
     Event,
+    FeatureFlag,
     Invitation,
     Organization,
     OrganizationMembership,


### PR DESCRIPTION
## Description

Adds `list_feature_flags` method to support `GET /organizations/:id/feature-flags`. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

Docs to be updated in **AUTH-5314**