### PR TITLE
add authenticate with invite_token to authenticate_with_code

### DIFF
--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -718,6 +718,37 @@ class TestUserManagement(UserManagementFixtures):
             "grant_type": "authorization_code",
         }
 
+    def test_authenticate_with_code_with_invitation_token(
+        self,
+        capture_and_mock_http_client_request,
+        mock_auth_response,
+        base_authentication_params,
+    ):
+        params = {
+            "code": "test_code",
+            "code_verifier": "test_code_verifier",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+            "ip_address": "192.0.0.1",
+            "invitation_token": "invitation_token_12345",
+        }
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_auth_response, 200
+        )
+
+        response = syncify(self.user_management.authenticate_with_code(**params))
+
+        assert request_kwargs["url"].endswith("user_management/authenticate")
+        assert request_kwargs["method"] == "post"
+        assert response.user.id == "user_01H7ZGXFP5C6BBQY6Z7277ZCT0"
+        assert response.organization_id == "org_12345"
+        assert response.access_token == "access_token_12345"
+        assert response.refresh_token == "refresh_token_12345"
+        assert request_kwargs["json"] == {
+            **params,
+            **base_authentication_params,
+            "grant_type": "authorization_code",
+        }
+
     def test_authenticate_with_magic_auth(
         self,
         capture_and_mock_http_client_request,

--- a/workos/types/user_management/authenticate_with_common.py
+++ b/workos/types/user_management/authenticate_with_common.py
@@ -19,6 +19,7 @@ class AuthenticateWithCodeParameters(AuthenticateWithBaseParameters):
     code_verifier: Union[str, None]
     grant_type: Literal["authorization_code"]
     session: Union[SessionConfig, None]
+    invitation_token: Union[str, None]
 
 
 class AuthenticateWithMagicAuthParameters(AuthenticateWithBaseParameters):

--- a/workos/user_management.py
+++ b/workos/user_management.py
@@ -488,6 +488,7 @@ class UserManagementModule(Protocol):
         code_verifier: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        invitation_token: Optional[str] = None,
     ) -> SyncOrAsync[AuthenticationResponse]:
         """Authenticates an OAuth user or a user that is logging in through SSO.
 
@@ -498,6 +499,7 @@ class UserManagementModule(Protocol):
                 url as part of the PKCE flow. This parameter is required when the client secret is not present. (Optional)
             ip_address (str): The IP address of the request from the user who is attempting to authenticate. (Optional)
             user_agent (str): The user agent of the request from the user who is attempting to authenticate. (Optional)
+            invitation_token (str): The token of an Invitation, if required. (Optional)
 
         Returns:
             AuthenticationResponse: Authentication response from WorkOS.
@@ -1166,6 +1168,7 @@ class UserManagement(UserManagementModule):
         code_verifier: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        invitation_token: Optional[str] = None,
     ) -> AuthKitAuthenticationResponse:
         if (
             session is not None
@@ -1181,6 +1184,7 @@ class UserManagement(UserManagementModule):
             "user_agent": user_agent,
             "code_verifier": code_verifier,
             "session": session,
+            "invitation_token": invitation_token,
         }
 
         return self._authenticate_with(
@@ -1807,6 +1811,7 @@ class AsyncUserManagement(UserManagementModule):
         code_verifier: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        invitation_token: Optional[str] = None,
     ) -> AuthKitAuthenticationResponse:
         if (
             session is not None
@@ -1822,6 +1827,7 @@ class AsyncUserManagement(UserManagementModule):
             "user_agent": user_agent,
             "code_verifier": code_verifier,
             "session": session,
+            "invitation_token": invitation_token,
         }
 
         return await self._authenticate_with(


### PR DESCRIPTION
## Description

Addressing this linear ticket here

https://linear.app/workos/issue/FEAT-1315/support-invitation-token-in-authenticate-call-in-the-python-sdk

Adding capability to authenticate_with_code using the invitation_token 

## Documentation

Does this require changes to the WorkOS Docs? 

```
[ X] Yes, this will require a change to the docs here 
```

API reference https://workos.com/docs/reference/authkit/authentication/code
(screenshots in linear ticket)

**I can add this to the docs too and create the PR, but I want to make sure this PR is approved first**

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.