### PR TITLE
Add `roles` to directory sync user and sso profile

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -30,6 +30,7 @@ class SSOFixtures:
             first_name=None,
             last_name=None,
             role=None,
+            roles=None,
             groups=None,
             raw_attributes={},
         ).dict()

--- a/tests/utils/fixtures/mock_directory_user.py
+++ b/tests/utils/fixtures/mock_directory_user.py
@@ -49,4 +49,5 @@ class MockDirectoryUser(DirectoryUserWithGroups):
                 ],
             },
             role=InlineRole(slug="member"),
+            roles=[InlineRole(slug="member")],
         )

--- a/tests/utils/fixtures/mock_profile.py
+++ b/tests/utils/fixtures/mock_profile.py
@@ -11,6 +11,7 @@ class MockProfile(Profile):
             first_name="WorkOS",
             last_name="Demo",
             role={"slug": "admin"},
+            roles=[{"slug": "admin"}],
             groups=["Admins", "Developers"],
             organization_id="org_01FG53X8636WSNW2WEKB2C31ZB",
             connection_id="conn_01EMH8WAK20T42N2NBMNBCYHAG",

--- a/workos/types/directory_sync/directory_user.py
+++ b/workos/types/directory_sync/directory_user.py
@@ -38,6 +38,7 @@ class DirectoryUser(WorkOSModel):
     created_at: str
     updated_at: str
     role: Optional[InlineRole] = None
+    roles: Optional[Sequence[InlineRole]] = None
 
     def primary_email(self) -> Union[DirectoryUserEmail, None]:
         return next((email for email in self.emails if email.primary), None)

--- a/workos/types/sso/profile.py
+++ b/workos/types/sso/profile.py
@@ -22,6 +22,7 @@ class Profile(WorkOSModel):
     last_name: Optional[str] = None
     idp_id: str
     role: Optional[ProfileRole] = None
+    roles: Optional[Sequence[ProfileRole]] = None
     groups: Optional[Sequence[str]] = None
     custom_attributes: Optional[Mapping[str, Any]] = None
     raw_attributes: Optional[Mapping[str, Any]] = None


### PR DESCRIPTION
## Description

Adds the `roles` field to directory user and sso profile to support multiple roles.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

- [X] Yes

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.