### PR TITLE
Add `read_object_by_name` method for Vault API

### DIFF
--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -107,6 +107,34 @@ class TestVault:
         ):
             self.vault.read_object(object_id=None)
 
+    def test_read_object_by_name_success(
+        self, mock_vault_object, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_vault_object, 200
+        )
+
+        vault_object = self.vault.read_object_by_name(name="test-secret")
+
+        assert request_kwargs["method"] == "get"
+        assert request_kwargs["url"].endswith("/vault/v1/kv/name/test-secret")
+        assert vault_object.id == "vault_01234567890abcdef"
+        assert vault_object.name == "test-secret"
+        assert vault_object.value == "secret-value"
+        assert vault_object.metadata.environment_id == "env_01234567890abcdef"
+
+    def test_read_object_by_name_missing_name(self):
+        with pytest.raises(
+            ValueError, match="Incomplete arguments: 'name' is a required argument"
+        ):
+            self.vault.read_object_by_name(name="")
+
+    def test_read_object_by_name_none_name(self):
+        with pytest.raises(
+            ValueError, match="Incomplete arguments: 'name' is a required argument"
+        ):
+            self.vault.read_object_by_name(name=None)
+
     def test_list_objects_default_params(
         self, mock_vault_objects_list, capture_and_mock_http_client_request
     ):

--- a/workos/vault.py
+++ b/workos/vault.py
@@ -37,6 +37,17 @@ class VaultModule(Protocol):
         """
         ...
 
+    def read_object_by_name(self, *, name: str) -> VaultObject:
+        """
+        Get a Vault object by name with the value decrypted.
+
+        Kwargs:
+            name (str): The unique name of the object.
+        Returns:
+            VaultObject: A vault object with metadata, name and decrypted value.
+        """
+        ...
+
     def list_objects(
         self,
         *,
@@ -224,6 +235,24 @@ class Vault(VaultModule):
             RequestHelper.build_parameterized_url(
                 "vault/v1/kv/{object_id}",
                 object_id=object_id,
+            ),
+            method=REQUEST_METHOD_GET,
+        )
+
+        return VaultObject.model_validate(response)
+
+    def read_object_by_name(
+        self,
+        *,
+        name: str,
+    ) -> VaultObject:
+        if not name:
+            raise ValueError("Incomplete arguments: 'name' is a required argument")
+
+        response = self._http_client.request(
+            RequestHelper.build_parameterized_url(
+                "vault/v1/kv/name/{name}",
+                name=name,
             ),
             method=REQUEST_METHOD_GET,
         )


### PR DESCRIPTION
## Description

This new endpoint matches the response of the existing ID-based read method. Names have enforced uniqueness.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/49387