### PR TITLE
Remove unused pypi environment for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,7 @@ jobs:
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    # Environment and permissions trusted publishing.
-    environment:
-      # Create this environment in the GitHub repository under Settings -> Environments
-      name: pypi
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

[Context is in this PR comment](https://github.com/workos/workos-python/pull/496#issuecomment-3740385801), but ultimately this PR changes the release workflow so that it doesn't work with environments (yet).

Environment creation / trusted publisher setup will happen in a future PR.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.