### PR TITLE
v5.39.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workos"
-version = "5.38.2"
+version = "5.39.0"
 description = "WorkOS Python Client"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "workos"
-version = "5.38.2"
+version = "5.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

This pull request makes a minor update to the project version in `pyproject.toml`, incrementing it from 5.38.1 to 5.39.0.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.