### PR TITLE
Add sso subdict to sso auth events

### DIFF
--- a/src/workos/types/events/authentication_payload.py
+++ b/src/workos/types/events/authentication_payload.py
@@ -61,10 +61,18 @@ class AuthenticationPasswordSucceededPayload(AuthenticationResultSucceeded):
     user_id: str
 
 
+class AuthenticationSsoData(WorkOSModel):
+    connection_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    session_id: Optional[str] = None
+
+
 class AuthenticationSsoFailedPayload(AuthenticationResultFailed):
     type: Literal["sso"]
+    sso: Optional[AuthenticationSsoData] = None
 
 
 class AuthenticationSsoSucceededPayload(AuthenticationResultSucceeded):
     type: Literal["sso"]
     user_id: Optional[str] = None
+    sso: Optional[AuthenticationSsoData] = None


### PR DESCRIPTION
## Description

This field is specified in the public docs - https://workos.com/docs/events - not sure if it should be optional or required

`{
  "event": "authentication.sso_succeeded",
  "id": "event_04FKJ843CVE8F7BXQSPFH0M53V",
  "data": {
    "type": "sso",
    "status": "succeeded",
    "user_id": "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
    "email": "todd@example.com",
    "ip_address": "192.0.2.1",
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36",
    "sso": {
      "connection_id": "conn_01FKJ843CVE8F7BXQSPFH0M53V",
      "organization_id": "org_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
      "session_id": "saml_session_01FKJ843CVE8F7BXQSPFH0M53V"
    }
  },
  "created_at": "2023-11-18T04:18:13.126Z",
  "context": {
    "client_id": "client_01JVPGDV8WDHN5V5X5BX7C58X1"
  }
}
`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.