### PR TITLE
feat: Add resource_type_slug to createOrganizationRole to create resource-scoped custom roles

### DIFF
--- a/src/workos/authorization.py
+++ b/src/workos/authorization.py
@@ -147,9 +147,10 @@ class AuthorizationModule(Protocol):
         self,
         organization_id: str,
         *,
-        slug: str,
+        slug: Optional[str] = None,
         name: str,
         description: Optional[str] = None,
+        resource_type_slug: Optional[str] = None,
     ) -> SyncOrAsync[OrganizationRole]: ...
 
     def list_organization_roles(
@@ -474,13 +475,18 @@ class Authorization(AuthorizationModule):
         self,
         organization_id: str,
         *,
-        slug: str,
+        slug: Optional[str] = None,
         name: str,
         description: Optional[str] = None,
+        resource_type_slug: Optional[str] = None,
     ) -> OrganizationRole:
-        json: Dict[str, Any] = {"slug": slug, "name": name}
+        json: Dict[str, Any] = {"name": name}
+        if slug is not None:
+            json["slug"] = slug
         if description is not None:
             json["description"] = description
+        if resource_type_slug is not None:
+            json["resource_type_slug"] = resource_type_slug
 
         response = self._http_client.request(
             f"authorization/organizations/{organization_id}/roles",
@@ -1152,13 +1158,18 @@ class AsyncAuthorization(AuthorizationModule):
         self,
         organization_id: str,
         *,
-        slug: str,
+        slug: Optional[str] = None,
         name: str,
         description: Optional[str] = None,
+        resource_type_slug: Optional[str] = None,
     ) -> OrganizationRole:
-        json: Dict[str, Any] = {"slug": slug, "name": name}
+        json: Dict[str, Any] = {"name": name}
+        if slug is not None:
+            json["slug"] = slug
         if description is not None:
             json["description"] = description
+        if resource_type_slug is not None:
+            json["resource_type_slug"] = resource_type_slug
 
         response = await self._http_client.request(
             f"authorization/organizations/{organization_id}/roles",

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -234,6 +234,45 @@ class TestAuthorization:
         )
         assert request_kwargs["json"] == {"slug": "admin", "name": "Admin"}
 
+    def test_create_organization_role_without_slug(
+        self, mock_organization_role, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_organization_role, 201
+        )
+
+        role = syncify(
+            self.authorization.create_organization_role(
+                "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+                name="Admin",
+            )
+        )
+
+        assert role.id == "role_01ABC"
+        assert request_kwargs["json"] == {"name": "Admin"}
+
+    def test_create_organization_role_with_resource_type_slug(
+        self, mock_organization_role, capture_and_mock_http_client_request
+    ):
+        request_kwargs = capture_and_mock_http_client_request(
+            self.http_client, mock_organization_role, 201
+        )
+
+        syncify(
+            self.authorization.create_organization_role(
+                "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+                slug="admin",
+                name="Admin",
+                resource_type_slug="project",
+            )
+        )
+
+        assert request_kwargs["json"] == {
+            "slug": "admin",
+            "name": "Admin",
+            "resource_type_slug": "project",
+        }
+
     def test_list_organization_roles(
         self, mock_organization_roles, capture_and_mock_http_client_request
     ):


### PR DESCRIPTION
Also makes permission slug optional. If omitted, the service will create auto-generated slugs