### PR TITLE
chore: mark non-spec service accessors with @oagen-ignore-start/end

### DIFF
--- a/.oagen-manifest.json
+++ b/.oagen-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "python",
-  "generatedAt": "2026-04-13T15:44:50.450Z",
+  "generatedAt": "2026-04-14T16:36:59.471Z",
   "files": [
     "src/workos/_client.py",
     "src/workos/admin_portal/__init__.py",

--- a/src/workos/_client.py
+++ b/src/workos/_client.py
@@ -28,10 +28,13 @@ from .user_management._resource import UserManagement, AsyncUserManagement
 from .webhooks._resource import Webhooks, AsyncWebhooks
 from .widgets._resource import Widgets, AsyncWidgets
 from .audit_logs._resource import AuditLogs, AsyncAuditLogs
+
+# @oagen-ignore-start — non-spec service imports (hand-maintained)
 from .passwordless import AsyncPasswordless, Passwordless
 from .vault import AsyncVault, Vault
 from .actions import Actions, AsyncActions
 from .pkce import PKCE
+# @oagen-ignore-end
 
 
 class WorkOSClient(_SyncBase):
@@ -127,6 +130,8 @@ class WorkOSClient(_SyncBase):
         """Alias for multi_factor_auth."""
         return self.multi_factor_auth
 
+    # @oagen-ignore-start — non-spec service accessors (hand-maintained)
+
     @functools.cached_property
     def passwordless(self) -> Passwordless:
         """Passwordless authentication sessions."""
@@ -146,6 +151,8 @@ class WorkOSClient(_SyncBase):
     def pkce(self) -> PKCE:
         """PKCE (Proof Key for Code Exchange) utilities."""
         return PKCE()
+
+    # @oagen-ignore-end
 
 
 class AsyncWorkOSClient(_AsyncBase):
@@ -241,6 +248,8 @@ class AsyncWorkOSClient(_AsyncBase):
         """Alias for multi_factor_auth."""
         return self.multi_factor_auth
 
+    # @oagen-ignore-start — non-spec service accessors (hand-maintained)
+
     @functools.cached_property
     def passwordless(self) -> AsyncPasswordless:
         """Passwordless authentication sessions."""
@@ -260,3 +269,5 @@ class AsyncWorkOSClient(_AsyncBase):
     def pkce(self) -> PKCE:
         """PKCE (Proof Key for Code Exchange) utilities."""
         return PKCE()
+
+    # @oagen-ignore-end


### PR DESCRIPTION
Previously, oagen-emitters generated methods for APIs not in the OpenAPI spec—stuff like Vault, PKCE, etc. This was kind of gross and unnecessary, so I removed the functionality in https://github.com/workos/oagen-emitters/commit/7b0bab4a622edd99aee7fcc37dd67b695384ef67 and am just tagging the relevant code sections with `oagen-ignore`, so that they do not get removed upon regeneration.