### PR TITLE
fix: do not JSON parse arbitrary bodies

### DIFF
--- a/src/workos/_base_client.py
+++ b/src/workos/_base_client.py
@@ -189,7 +189,7 @@ class _BaseWorkOSClient:
     def _deserialize_response(
         self, response: httpx.Response, model: Optional[Type[Deserializable]]
     ) -> Any:
-        if response.status_code == 204 or not response.content:
+        if response.status_code == 204 or not response.content or model is None:
             return None
         data: Dict[str, Any] = cast(Dict[str, Any], response.json())
         if model is not None:

--- a/src/workos/_base_client.py
+++ b/src/workos/_base_client.py
@@ -189,11 +189,14 @@ class _BaseWorkOSClient:
     def _deserialize_response(
         self, response: httpx.Response, model: Optional[Type[Deserializable]]
     ) -> Any:
-        if response.status_code == 204 or not response.content or model is None:
+        if response.status_code == 204 or not response.content:
             return None
-        data: Dict[str, Any] = cast(Dict[str, Any], response.json())
+        try:
+            data = response.json()
+        except Exception:
+            return None
         if model is not None:
-            return model.from_dict(data)
+            return model.from_dict(cast(Dict[str, Any], data))
         return data
 
     @staticmethod

--- a/tests/test_generated_client.py
+++ b/tests/test_generated_client.py
@@ -451,6 +451,33 @@ class TestWorkOSClient:
         assert client.widgets is not None
         client.close()
 
+    def test_request_raw_preserves_json_dict_response(self, httpx_mock):
+        httpx_mock.add_response(json={"ok": True})
+        client = WorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = client.request_raw("GET", "test")
+        assert result == {"ok": True}
+        client.close()
+
+    def test_request_list_preserves_json_array_response(self, httpx_mock):
+        httpx_mock.add_response(json=[{"id": "item_123"}])
+        client = WorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = client.request_list("GET", "test")
+        assert result == [{"id": "item_123"}]
+        client.close()
+
+    def test_request_returns_none_for_non_json_success_without_model(self, httpx_mock):
+        httpx_mock.add_response(status_code=202, content=b"\n")
+        client = WorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = client.request("DELETE", "test")
+        assert result is None
+        client.close()
+
 
 @pytest.mark.asyncio
 class TestAsyncWorkOSClient:
@@ -473,6 +500,35 @@ class TestAsyncWorkOSClient:
         assert client.user_management is not None
         assert client.webhooks is not None
         assert client.widgets is not None
+        await client.close()
+
+    async def test_request_raw_preserves_json_dict_response(self, httpx_mock):
+        httpx_mock.add_response(json={"ok": True})
+        client = AsyncWorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = await client.request_raw("GET", "test")
+        assert result == {"ok": True}
+        await client.close()
+
+    async def test_request_list_preserves_json_array_response(self, httpx_mock):
+        httpx_mock.add_response(json=[{"id": "item_123"}])
+        client = AsyncWorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = await client.request_list("GET", "test")
+        assert result == [{"id": "item_123"}]
+        await client.close()
+
+    async def test_request_returns_none_for_non_json_success_without_model(
+        self, httpx_mock
+    ):
+        httpx_mock.add_response(status_code=202, content=b"\n")
+        client = AsyncWorkOSClient(
+            api_key="sk_test_123", client_id="client_test", max_retries=0
+        )
+        result = await client.request("DELETE", "test")
+        assert result is None
         await client.close()
 
     async def test_raises_400(self, httpx_mock):

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -108,7 +108,7 @@ class TestOrganizations:
         assert request.url.path.endswith("/organizations/test_id")
 
     def test_delete_organization(self, workos, httpx_mock):
-        httpx_mock.add_response(status_code=204)
+        httpx_mock.add_response(status_code=202, content=b"\n")
         result = workos.organizations.delete_organization("test_id")
         assert result is None
         request = httpx_mock.get_request()
@@ -289,7 +289,7 @@ class TestAsyncOrganizations:
 
     @pytest.mark.asyncio
     async def test_delete_organization(self, async_workos, httpx_mock):
-        httpx_mock.add_response(status_code=204)
+        httpx_mock.add_response(status_code=202, content=b"\n")
         result = await async_workos.organizations.delete_organization("test_id")
         assert result is None
         request = httpx_mock.get_request()


### PR DESCRIPTION
The client should not always assume that the API response is going to be JSON.

fixes https://github.com/workos/workos-python/issues/626