### PR TITLE
fix: list Slack as an auth provider for the authorization URL

### DIFF
--- a/src/workos/sso/models/sso_provider.py
+++ b/src/workos/sso/models/sso_provider.py
@@ -13,9 +13,19 @@ class SSOProvider(str, Enum):
     """Known values for SSOProvider."""
 
     APPLE_OAUTH = "AppleOAuth"
+    BITBUCKET_OAUTH = "BitbucketOAuth"
+    DISCORD_OAUTH = "DiscordOAuth"
     GIT_HUB_OAUTH = "GitHubOAuth"
+    GIT_LAB_OAUTH = "GitLabOAuth"
     GOOGLE_OAUTH = "GoogleOAuth"
+    INTUIT_OAUTH = "IntuitOAuth"
+    LINKED_IN_OAUTH = "LinkedInOAuth"
     MICROSOFT_OAUTH = "MicrosoftOAuth"
+    SALESFORCE_OAUTH = "SalesforceOAuth"
+    SLACK_OAUTH = "SlackOAuth"
+    VERCEL_MARKETPLACE_OAUTH = "VercelMarketplaceOAuth"
+    VERCEL_OAUTH = "VercelOAuth"
+    XERO_OAUTH = "XeroOAuth"
 
     @classmethod
     def _missing_(cls, value: object) -> Optional["SSOProvider"]:
@@ -28,5 +38,18 @@ class SSOProvider(str, Enum):
 
 
 SSOProviderLiteral: TypeAlias = Literal[
-    "AppleOAuth", "GitHubOAuth", "GoogleOAuth", "MicrosoftOAuth"
+    "AppleOAuth",
+    "BitbucketOAuth",
+    "DiscordOAuth",
+    "GitHubOAuth",
+    "GitLabOAuth",
+    "GoogleOAuth",
+    "IntuitOAuth",
+    "LinkedInOAuth",
+    "MicrosoftOAuth",
+    "SalesforceOAuth",
+    "SlackOAuth",
+    "VercelMarketplaceOAuth",
+    "VercelOAuth",
+    "XeroOAuth",
 ]

--- a/src/workos/user_management/models/user_management_authentication_provider.py
+++ b/src/workos/user_management/models/user_management_authentication_provider.py
@@ -17,6 +17,7 @@ class UserManagementAuthenticationProvider(str, Enum):
     GIT_HUB_OAUTH = "GitHubOAuth"
     GOOGLE_OAUTH = "GoogleOAuth"
     MICROSOFT_OAUTH = "MicrosoftOAuth"
+    SLACK_OAUTH = "SlackOAuth"
 
     @classmethod
     def _missing_(
@@ -31,5 +32,5 @@ class UserManagementAuthenticationProvider(str, Enum):
 
 
 UserManagementAuthenticationProviderLiteral: TypeAlias = Literal[
-    "authkit", "AppleOAuth", "GitHubOAuth", "GoogleOAuth", "MicrosoftOAuth"
+    "authkit", "AppleOAuth", "GitHubOAuth", "GoogleOAuth", "MicrosoftOAuth", "SlackOAuth"
 ]

--- a/src/workos/user_management/models/user_management_authentication_provider.py
+++ b/src/workos/user_management/models/user_management_authentication_provider.py
@@ -5,8 +5,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
-from typing import Literal, TypeAlias
+from typing import Literal, Optional, TypeAlias
 
 
 class UserManagementAuthenticationProvider(str, Enum):
@@ -14,10 +13,19 @@ class UserManagementAuthenticationProvider(str, Enum):
 
     AUTHKIT = "authkit"
     APPLE_OAUTH = "AppleOAuth"
+    BITBUCKET_OAUTH = "BitbucketOAuth"
+    DISCORD_OAUTH = "DiscordOAuth"
     GIT_HUB_OAUTH = "GitHubOAuth"
+    GIT_LAB_OAUTH = "GitLabOAuth"
     GOOGLE_OAUTH = "GoogleOAuth"
+    INTUIT_OAUTH = "IntuitOAuth"
+    LINKED_IN_OAUTH = "LinkedInOAuth"
     MICROSOFT_OAUTH = "MicrosoftOAuth"
+    SALESFORCE_OAUTH = "SalesforceOAuth"
     SLACK_OAUTH = "SlackOAuth"
+    VERCEL_MARKETPLACE_OAUTH = "VercelMarketplaceOAuth"
+    VERCEL_OAUTH = "VercelOAuth"
+    XERO_OAUTH = "XeroOAuth"
 
     @classmethod
     def _missing_(
@@ -32,5 +40,19 @@ class UserManagementAuthenticationProvider(str, Enum):
 
 
 UserManagementAuthenticationProviderLiteral: TypeAlias = Literal[
-    "authkit", "AppleOAuth", "GitHubOAuth", "GoogleOAuth", "MicrosoftOAuth", "SlackOAuth"
+    "authkit",
+    "AppleOAuth",
+    "BitbucketOAuth",
+    "DiscordOAuth",
+    "GitHubOAuth",
+    "GitLabOAuth",
+    "GoogleOAuth",
+    "IntuitOAuth",
+    "LinkedInOAuth",
+    "MicrosoftOAuth",
+    "SalesforceOAuth",
+    "SlackOAuth",
+    "VercelMarketplaceOAuth",
+    "VercelOAuth",
+    "XeroOAuth",
 ]


### PR DESCRIPTION
## Description

Slack wasn't in here, but it works. I want to use it in `workos_client.user_management.get_authorization_url`. (This list seems somewhat inconsistent with other lists).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] No
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.