### PR TITLE
fix: set canonical User-Agent header format

### DIFF
--- a/src/workos/_base_client.py
+++ b/src/workos/_base_client.py
@@ -167,7 +167,7 @@ class _BaseWorkOSClient:
     ) -> Dict[str, str]:
         headers: Dict[str, str] = {
             "Content-Type": "application/json",
-            "User-Agent": f"workos-python/{VERSION} python/{platform.python_version()}",
+            "User-Agent": f"WorkOS Python/{platform.python_version()} Python SDK/{VERSION}",
         }
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"


### PR DESCRIPTION
## Summary

Sets the outgoing `User-Agent` header to `WorkOS Python/{python_version} Python SDK/{VERSION}` — the canonical WorkOS Python SDK format used through the 5.x line. The 6.0.0 release inadvertently shipped a different shape (`workos-python/{VERSION} python/{python_version}`) that no longer conformed.

Same data, restored ordering.

## Test plan

- [x] `uv run pytest tests/` (1987 passed)
- [ ] Confirm User-Agent in a real outgoing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-python/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
