### PR TITLE
feat: add `get_jwks_url` helper to UserManagement

### DIFF
--- a/src/workos/user_management/_resource.py
+++ b/src/workos/user_management/_resource.py
@@ -2098,6 +2098,23 @@ class UserManagement:
 
     # @oagen-ignore-start
 
+    def get_jwks_url(self, client_id: Optional[str] = None) -> str:
+        """Get the JWKS URL used to verify access tokens.
+
+        Use this when integrating with a JWT library that fetches and caches
+        the JWKS itself (e.g. ``PyJWKClient``). For the JWKS document, call
+        :meth:`get_jwks` instead.
+
+        Args:
+            client_id: The WorkOS client ID. Defaults to the client's
+                configured client_id.
+
+        Returns:
+            The JWKS URL.
+        """
+        resolved_client_id = client_id or self._client._require_client_id()
+        return f"{self._client.base_url}sso/jwks/{resolved_client_id}"
+
     def load_sealed_session(
         self,
         *,
@@ -4265,6 +4282,23 @@ class AsyncUserManagement:
         )
 
     # @oagen-ignore-start
+
+    def get_jwks_url(self, client_id: Optional[str] = None) -> str:
+        """Get the JWKS URL used to verify access tokens.
+
+        Use this when integrating with a JWT library that fetches and caches
+        the JWKS itself (e.g. ``PyJWKClient``). For the JWKS document, call
+        :meth:`get_jwks` instead.
+
+        Args:
+            client_id: The WorkOS client ID. Defaults to the client's
+                configured client_id.
+
+        Returns:
+            The JWKS URL.
+        """
+        resolved_client_id = client_id or self._client._require_client_id()
+        return f"{self._client.base_url}sso/jwks/{resolved_client_id}"
 
     def load_sealed_session(
         self,

--- a/tests/test_inline_helpers.py
+++ b/tests/test_inline_helpers.py
@@ -271,3 +271,35 @@ class TestAsyncSSOPKCECodeExchange:
         request = httpx_mock.get_request()
         body = json.loads(request.content)
         assert body["code_verifier"] == "test_verifier_abc"
+
+
+class TestGetJwksUrl:
+    def test_uses_configured_client_id(self, workos):
+        url = workos.user_management.get_jwks_url()
+        assert url == "https://api.workos.com/sso/jwks/client_test"
+
+    def test_explicit_client_id_overrides_default(self, workos):
+        url = workos.user_management.get_jwks_url("client_other")
+        assert url == "https://api.workos.com/sso/jwks/client_other"
+
+    def test_raises_when_no_client_id_configured(self):
+        from workos import WorkOSClient
+        from workos._errors import ConfigurationError
+
+        client = WorkOSClient(api_key="sk_test_abc")
+        try:
+            with pytest.raises(ConfigurationError):
+                client.user_management.get_jwks_url()
+        finally:
+            client.close()
+
+
+@pytest.mark.asyncio
+class TestAsyncGetJwksUrl:
+    async def test_uses_configured_client_id(self, async_workos):
+        url = async_workos.user_management.get_jwks_url()
+        assert url == "https://api.workos.com/sso/jwks/client_test"
+
+    async def test_explicit_client_id_overrides_default(self, async_workos):
+        url = async_workos.user_management.get_jwks_url("client_other")
+        assert url == "https://api.workos.com/sso/jwks/client_other"


### PR DESCRIPTION
## Summary

Adds `user_management.get_jwks_url(client_id=None)` to both sync and async clients — a small helper that constructs the JWKS URL for a given client.

### Why

v6 exposed `user_management.get_jwks_url()`, which customers used to integrate with JWT libraries that take a URL and handle fetching/caching themselves (e.g. PyJWT's `PyJWKClient(url)`). v7's generated `get_jwks(client_id)` returns the JWKS *document*, not the URL — so customers integrating with URL-based JWT libraries have been hand-constructing the URL with `f"{client.base_url}sso/jwks/{client_id}"`, duplicating what `session.py` does internally.

### Implementation

- Adds `get_jwks_url` to `UserManagement` and `AsyncUserManagement` inside the existing `@oagen-ignore-start` / `@oagen-ignore-end` fences in `src/workos/user_management/_resource.py`. Verified the methods survive `npm run sdk:generate -- --lang python`.
- Parameter is `Optional[str]` with fallback to the client's configured `client_id` via `_require_client_id()` — matches v6 ergonomics where the method took no arguments.
- URL construction mirrors `session.py:195` / `session.py:373` exactly.

## Test plan

- [x] `uv run pytest tests/test_inline_helpers.py -k "JwksUrl"` — 5 new tests pass (default lookup, explicit override, `ConfigurationError` when no client_id; sync + async)
- [x] `uv run pytest tests/test_inline_helpers.py tests/test_user_management.py tests/test_session.py` — 184 tests pass
- [x] `uv run ruff format --check` and `uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors
- [x] Verified `get_jwks_url` survives a full `npm run sdk:generate` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-python/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
