### PR TITLE
feat: Add roles field to OrganizationMembership models

### DIFF
--- a/src/workos/common/models/user_organization_membership_base_list_data.py
+++ b/src/workos/common/models/user_organization_membership_base_list_data.py
@@ -6,10 +6,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import cast
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from workos._types import _raise_deserialize_error
 from workos._types import _format_datetime, _parse_datetime
 
+from .slim_role import SlimRole
 from .user import User
 from .user_organization_membership_base_list_data_status import (
     UserOrganizationMembershipBaseListDataStatus,
@@ -38,6 +39,8 @@ class UserOrganizationMembershipBaseListData:
     """An ISO 8601 timestamp."""
     user: "User"
     """The user that belongs to the organization through this membership."""
+    roles: Optional[List["SlimRole"]] = None
+    """The roles assigned to the user within the organization."""
     organization_name: Optional[str] = None
     """The name of the organization which the user belongs to."""
     custom_attributes: Optional[Dict[str, Any]] = None
@@ -59,6 +62,12 @@ class UserOrganizationMembershipBaseListData:
                 created_at=_parse_datetime(data["created_at"]),
                 updated_at=_parse_datetime(data["updated_at"]),
                 user=User.from_dict(cast(Dict[str, Any], data["user"])),
+                roles=[
+                    SlimRole.from_dict(cast(Dict[str, Any], item))
+                    for item in cast(list[Any], _v_roles)
+                ]
+                if (_v_roles := data.get("roles")) is not None
+                else None,
                 organization_name=data.get("organization_name"),
                 custom_attributes=data.get("custom_attributes"),
             )
@@ -79,6 +88,8 @@ class UserOrganizationMembershipBaseListData:
         result["created_at"] = _format_datetime(self.created_at)
         result["updated_at"] = _format_datetime(self.updated_at)
         result["user"] = self.user.to_dict()
+        if self.roles is not None:
+            result["roles"] = [item.to_dict() for item in self.roles]
         if self.organization_name is not None:
             result["organization_name"] = self.organization_name
         if self.custom_attributes is not None:

--- a/src/workos/organization_membership/models/organization_membership.py
+++ b/src/workos/organization_membership/models/organization_membership.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import cast
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from workos._types import _raise_deserialize_error
 from workos._types import _format_datetime, _parse_datetime
 
@@ -41,6 +41,8 @@ class OrganizationMembership:
     """The primary role assigned to the user within the organization."""
     user: "User"
     """The user that belongs to the organization through this membership."""
+    roles: Optional[List["SlimRole"]] = None
+    """The roles assigned to the user within the organization."""
     organization_name: Optional[str] = None
     """The name of the organization which the user belongs to."""
     custom_attributes: Optional[Dict[str, Any]] = None
@@ -61,6 +63,12 @@ class OrganizationMembership:
                 updated_at=_parse_datetime(data["updated_at"]),
                 role=SlimRole.from_dict(cast(Dict[str, Any], data["role"])),
                 user=User.from_dict(cast(Dict[str, Any], data["user"])),
+                roles=[
+                    SlimRole.from_dict(cast(Dict[str, Any], item))
+                    for item in cast(list[Any], _v_roles)
+                ]
+                if (_v_roles := data.get("roles")) is not None
+                else None,
                 organization_name=data.get("organization_name"),
                 custom_attributes=data.get("custom_attributes"),
             )
@@ -82,6 +90,8 @@ class OrganizationMembership:
         result["updated_at"] = _format_datetime(self.updated_at)
         result["role"] = self.role.to_dict()
         result["user"] = self.user.to_dict()
+        if self.roles is not None:
+            result["roles"] = [item.to_dict() for item in self.roles]
         if self.organization_name is not None:
             result["organization_name"] = self.organization_name
         if self.custom_attributes is not None:

--- a/tests/fixtures/list_user_organization_membership.json
+++ b/tests/fixtures/list_user_organization_membership.json
@@ -18,6 +18,11 @@
       "role": {
         "slug": "admin"
       },
+      "roles": [
+        {
+          "slug": "admin"
+        }
+      ],
       "user": {
         "object": "user",
         "id": "user_01E4ZCR3C56J083X43JQXF3JK5",

--- a/tests/fixtures/list_user_organization_membership_base_list_data.json
+++ b/tests/fixtures/list_user_organization_membership_base_list_data.json
@@ -15,6 +15,11 @@
       },
       "created_at": "2026-01-15T12:00:00.000Z",
       "updated_at": "2026-01-15T12:00:00.000Z",
+      "roles": [
+        {
+          "slug": "admin"
+        }
+      ],
       "user": {
         "object": "user",
         "id": "user_01E4ZCR3C56J083X43JQXF3JK5",

--- a/tests/fixtures/organization_membership.json
+++ b/tests/fixtures/organization_membership.json
@@ -16,6 +16,11 @@
   "role": {
     "slug": "admin"
   },
+  "roles": [
+    {
+      "slug": "admin"
+    }
+  ],
   "user": {
     "object": "user",
     "id": "user_01E4ZCR3C56J083X43JQXF3JK5",

--- a/tests/fixtures/user_organization_membership.json
+++ b/tests/fixtures/user_organization_membership.json
@@ -16,6 +16,11 @@
   "role": {
     "slug": "admin"
   },
+  "roles": [
+    {
+      "slug": "admin"
+    }
+  ],
   "user": {
     "object": "user",
     "id": "user_01E4ZCR3C56J083X43JQXF3JK5",

--- a/tests/fixtures/user_organization_membership_base_list_data.json
+++ b/tests/fixtures/user_organization_membership_base_list_data.json
@@ -13,6 +13,11 @@
   },
   "created_at": "2026-01-15T12:00:00.000Z",
   "updated_at": "2026-01-15T12:00:00.000Z",
+  "roles": [
+    {
+      "slug": "admin"
+    }
+  ],
   "user": {
     "object": "user",
     "id": "user_01E4ZCR3C56J083X43JQXF3JK5",

--- a/tests/test_models_round_trip.py
+++ b/tests/test_models_round_trip.py
@@ -16857,6 +16857,7 @@ class TestModelRoundTrip:
         }
         instance = UserOrganizationMembershipBaseListData.from_dict(data)
         serialized = instance.to_dict()
+        assert "roles" not in serialized
         assert "organization_name" not in serialized
         assert "custom_attributes" not in serialized
 
@@ -17542,6 +17543,7 @@ class TestModelRoundTrip:
         }
         instance = OrganizationMembership.from_dict(data)
         serialized = instance.to_dict()
+        assert "roles" not in serialized
         assert "organization_name" not in serialized
         assert "custom_attributes" not in serialized
 


### PR DESCRIPTION
## Description

The `OrganizationMembership` model only exposed `role: SlimRole` (singular), but the API also returns `roles: List[SlimRole]` for multiple-role support. The event model (`OrganizationMembershipCreatedData`) already had this field — this PR adds it to the two remaining models:

- `OrganizationMembership` — used by `list_organization_memberships`, `get_organization_membership`, `create_organization_membership`, etc.
- `UserOrganizationMembershipBaseListData` — used by authorization and groups listing endpoints

The field is `Optional[List[SlimRole]]` (defaults to `None`), matching the existing pattern in `OrganizationMembershipCreatedData`. Backward compatible — `role` is unchanged, and `roles` gracefully handles absence from older API responses.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

Link to Devin session: https://app.devin.ai/sessions/896e93121dcd42839221cfd4cebfec33
Requested by: @ethinallen