### PR TITLE
feat: add get_profile_and_token_from_id_token for OIDC ID token exchange (4.16.0 backport)

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -424,6 +424,40 @@ class TestSSO(object):
         assert profile_and_token.access_token == "01DY34ACQTM3B1CSX1YSZ8Z00D"
         assert profile_and_token.profile.to_dict() == mock_profile
 
+    def test_get_profile_and_token_from_id_token_returns_expected_workosprofile_object(
+        self, setup_with_client_id, mock_profile, mock_request_method
+    ):
+        response_dict = {
+            "profile": {
+                "object": "profile",
+                "id": mock_profile["id"],
+                "email": mock_profile["email"],
+                "first_name": mock_profile["first_name"],
+                "groups": mock_profile["groups"],
+                "organization_id": mock_profile["organization_id"],
+                "connection_id": mock_profile["connection_id"],
+                "connection_type": mock_profile["connection_type"],
+                "last_name": mock_profile["last_name"],
+                "idp_id": mock_profile["idp_id"],
+                "raw_attributes": {
+                    "email": mock_profile["raw_attributes"]["email"],
+                    "first_name": mock_profile["raw_attributes"]["first_name"],
+                    "last_name": mock_profile["raw_attributes"]["last_name"],
+                    "groups": mock_profile["raw_attributes"]["groups"],
+                },
+            },
+            "access_token": "01DY34ACQTM3B1CSX1YSZ8Z00D",
+        }
+
+        mock_request_method("post", response_dict, 200)
+
+        profile_and_token = self.sso.get_profile_and_token_from_id_token(
+            "eyJhbGciOiJSUzI1NiJ9.id.token", "org_01EHQMYV6MBK39QC5PZXHY59C3"
+        )
+
+        assert profile_and_token.access_token == "01DY34ACQTM3B1CSX1YSZ8Z00D"
+        assert profile_and_token.profile.to_dict() == mock_profile
+
     def test_get_profile_and_token_without_first_name_or_last_name_returns_expected_workosprofile_object(
         self, setup_with_client_id, mock_magic_link_profile, mock_request_method
     ):

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "4.15.0"
+__version__ = "4.16.0"
 
 __author__ = "WorkOS"
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -24,6 +24,8 @@ TOKEN_PATH = "sso/token"
 PROFILE_PATH = "sso/profile"
 
 OAUTH_GRANT_TYPE = "authorization_code"
+TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+ID_TOKEN_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token"
 
 RESPONSE_LIMIT = 10
 
@@ -154,6 +156,39 @@ class SSO(WorkOSListResource):
             "client_secret": workos.api_key,
             "code": code,
             "grant_type": OAUTH_GRANT_TYPE,
+        }
+
+        response = self.request_helper.request(
+            TOKEN_PATH, method=REQUEST_METHOD_POST, params=params
+        )
+
+        return WorkOSProfileAndToken.construct_from_response(response)
+
+    def get_profile_and_token_from_id_token(self, id_token, organization_id):
+        """Exchange an externally issued OIDC ID token for a Profile and Token
+
+        For flows where the user authenticates natively with the identity
+        provider (for example a mobile app using MSAL against Microsoft Entra)
+        and no browser redirect occurs. The ID token is exchanged for the same
+        WorkOS profile the authorization code flow would return. The connection
+        must have an ID token trust configured for the token's issuer and
+        audience.
+
+        Args:
+            id_token (str): The OIDC ID token issued to the client.
+            organization_id (str): The organization whose connection the ID
+                token should be validated against.
+
+        Returns:
+            WorkOSProfileAndToken: WorkOSProfileAndToken object representing the User
+        """
+        params = {
+            "client_id": workos.client_id,
+            "client_secret": workos.api_key,
+            "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+            "subject_token": id_token,
+            "subject_token_type": ID_TOKEN_SUBJECT_TOKEN_TYPE,
+            "organization_id": organization_id,
         }
 
         response = self.request_helper.request(


### PR DESCRIPTION
## Summary

Backport onto the 4.x line for customers who need the `/sso/token` **token-exchange grant** (native MSAL sign-in: a mobile app gets an Entra ID token and the backend exchanges it for a WorkOS profile) but are still on 4.x and can't move to 10.x yet.

Adds a new, additive SSO method:

```python
sso.get_profile_and_token_from_id_token(id_token, organization_id)
```

It POSTs the token-exchange grant (`grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `subject_token`, `subject_token_type=...:id_token`, `organization_id`) to `/sso/token` and returns the same `WorkOSProfileAndToken` as the authorization-code flow. Existing `get_profile_and_token` is untouched.

Version bumped 4.15.0 → **4.16.0** (additive, non-breaking). Added a unit test mirroring the existing `get_profile_and_token` test; `pytest tests/test_sso.py` passes locally.

## Why a 4.x backport (and why isolated)

- The feature only exists on the 4.x branch as a hand-written method; the 10.x line is `oagen`-generated and will get this through codegen separately. This branch does not touch `main` / 10.x.
- Publishing 4.16.0 will not change `pip install workos` defaults: PyPI serves the highest version (10.2.0) as latest, so only an explicit `workos==4.16.0` pin picks this up.
- Base is a new `4.x` branch cut from `v4.15.0` so the diff is just this change.

## ⚠️ Draft — needs a maintainer to own the release

I can't publish to PyPI. Before release, please confirm the 4.x release/CI process still works from this branch, the version bump is where you want it, and whether you want the same method mirrored into the 10.x codegen path so it doesn't regress on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)